### PR TITLE
Allow Argument#default to be a function

### DIFF
--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -15,6 +15,7 @@ class Argument {
 	 * @property {number} [min] - If type is `integer` or `float`, this is the minimum value of the number.
 	 * If type is `string`, this is the minimum length of the string.
 	 * @property {*} [default] - Default value for the argument (makes the argument optional - cannot be `null`)
+	 * If a function, the function will be executed with an argument for the CommandMessage
 	 * @property {boolean} [infinite=false] - Whether the argument accepts infinite values
 	 * @property {Function} [validate] - Validator function for the argument (see {@link ArgumentType#validate})
 	 * @property {Function} [parse] - Parser function for the argument (see {@link ArgumentType#parse})
@@ -130,7 +131,7 @@ class Argument {
 		const empty = this.isEmpty(value, msg);
 		if(empty && this.default !== null) {
 			return {
-				value: this.default,
+				value: typeof this.default === 'function' ? this.default(msg) : this.default,
 				cancelled: null,
 				prompts: [],
 				answers: []

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -14,13 +14,19 @@ class Argument {
 	 * If type is `string`, this is the maximum length of the string.
 	 * @property {number} [min] - If type is `integer` or `float`, this is the minimum value of the number.
 	 * If type is `string`, this is the minimum length of the string.
-	 * @property {*|Function} [default] - Default value for the argument (makes the argument optional - cannot be `null`)
+	 * @property {ArgumentDefault} [default] - Default value for the argument (makes the argument optional - cannot be `null`)
 	 * If a function, the function will be executed with an argument for the CommandMessage
 	 * @property {boolean} [infinite=false] - Whether the argument accepts infinite values
 	 * @property {Function} [validate] - Validator function for the argument (see {@link ArgumentType#validate})
 	 * @property {Function} [parse] - Parser function for the argument (see {@link ArgumentType#parse})
 	 * @property {Function} [isEmpty] - Empty checker for the argument (see {@link ArgumentType#isEmpty})
 	 * @property {number} [wait=30] - How long to wait for input (in seconds)
+	 */
+
+	/**
+	 * @typedef {*|Function} ArgumentDefault
+	 * @param {CommandMessage} message - The message that initiated the command
+	 * @param {Argument} argument - The argument class this argument is a part of
 	 */
 
 	/**
@@ -70,7 +76,7 @@ class Argument {
 
 		/**
 		 * The default value for the argument
-		 * @type {?*|Function}
+		 * @type {?ArgumentDefault}
 		 */
 		this.default = typeof info.default !== 'undefined' ? info.default : null;
 

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -14,7 +14,7 @@ class Argument {
 	 * If type is `string`, this is the maximum length of the string.
 	 * @property {number} [min] - If type is `integer` or `float`, this is the minimum value of the number.
 	 * If type is `string`, this is the minimum length of the string.
-	 * @property {*} [default] - Default value for the argument (makes the argument optional - cannot be `null`)
+	 * @property {*|Function} [default] - Default value for the argument (makes the argument optional - cannot be `null`)
 	 * If a function, the function will be executed with an argument for the CommandMessage
 	 * @property {boolean} [infinite=false] - Whether the argument accepts infinite values
 	 * @property {Function} [validate] - Validator function for the argument (see {@link ArgumentType#validate})

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -15,7 +15,6 @@ class Argument {
 	 * @property {number} [min] - If type is `integer` or `float`, this is the minimum value of the number.
 	 * If type is `string`, this is the minimum length of the string.
 	 * @property {ArgumentDefault} [default] - Default value for the argument (makes the argument optional - cannot be `null`)
-	 * If a function, the function will be executed with an argument for the CommandMessage
 	 * @property {boolean} [infinite=false] - Whether the argument accepts infinite values
 	 * @property {Function} [validate] - Validator function for the argument (see {@link ArgumentType#validate})
 	 * @property {Function} [parse] - Parser function for the argument (see {@link ArgumentType#parse})

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -131,7 +131,7 @@ class Argument {
 		const empty = this.isEmpty(value, msg);
 		if(empty && this.default !== null) {
 			return {
-				value: typeof this.default === 'function' ? this.default(msg) : this.default,
+				value: typeof this.default === 'function' ? this.default(msg, this) : this.default,
 				cancelled: null,
 				prompts: [],
 				answers: []

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -14,7 +14,7 @@ class Argument {
 	 * If type is `string`, this is the maximum length of the string.
 	 * @property {number} [min] - If type is `integer` or `float`, this is the minimum value of the number.
 	 * If type is `string`, this is the minimum length of the string.
-	 * @property {ArgumentDefault} [default] - Default value for the argument (makes the argument optional - cannot be `null`)
+	 * @property {ArgumentDefault} [default] - Default value for the argument (makes the arg optional - cannot be `null`)
 	 * @property {boolean} [infinite=false] - Whether the argument accepts infinite values
 	 * @property {Function} [validate] - Validator function for the argument (see {@link ArgumentType#validate})
 	 * @property {Function} [parse] - Parser function for the argument (see {@link ArgumentType#parse})

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -24,9 +24,8 @@ class Argument {
 	 */
 
 	/**
+	 * Either a value or a function that returns a value. The function is passed the CommandMessage and the Argument.
 	 * @typedef {*|Function} ArgumentDefault
-	 * @param {CommandMessage} message - The message that initiated the command
-	 * @param {Argument} argument - The argument class this argument is a part of
 	 */
 
 	/**

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -70,7 +70,7 @@ class Argument {
 
 		/**
 		 * The default value for the argument
-		 * @type {?*}
+		 * @type {?*|Function}
 		 */
 		this.default = typeof info.default !== 'undefined' ? info.default : null;
 


### PR DESCRIPTION
One of the most annoying things about commando is the fact that to set a `default` for an argument as, say, the message author, you have to set it to `''` and then check for that in the `run` function.

This PR introduces a much cleaner way to handle `default` when it needs to be something dependent on the `Message` object, by making it to where you can set the `default` to a function, which will be executed with the `Message` object as the first parameter. This allows very clean parsing for the arguments, and looks much nicer in comparison.

`default: msg => msg.author`