### PR TITLE
type intellisense fix

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -5,7 +5,7 @@ const GuildSettingsHelper = require('./providers/helper');
 
 /**
  * Discord.js Client with a command framework
- * @extends {Client}
+ * @extends {discord.Client}
  */
 class CommandoClient extends discord.Client {
 	/**


### PR DESCRIPTION
vscode's intellisense could not detect that the CommandoClient class inherited the Client class from discord.js. simple doc fix