### PR TITLE
Add unhandledErrorResponse option, to ignore unhandled errors

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -16,6 +16,7 @@ class CommandoClient extends discord.Client {
 	 * @property {number} [commandEditableDuration=30] - Time in seconds that command messages should be editable
 	 * @property {boolean} [nonCommandEditable=true] - Whether messages without commands can be edited to a command
 	 * @property {boolean} [unknownCommandResponse=true] - Whether the bot should respond to an unknown command
+	 * @property {boolean} [unhandledErrorResponse=true] - Whether the bot should respond to an unhandled error
 	 * @property {string|string[]|Set<string>} [owner] - ID of the bot owner's Discord user, or multiple IDs
 	 * @property {string} [invite] - Invite URL to the bot's support server
 	 */
@@ -30,6 +31,7 @@ class CommandoClient extends discord.Client {
 		if(typeof options.commandEditableDuration === 'undefined') options.commandEditableDuration = 30;
 		if(typeof options.nonCommandEditable === 'undefined') options.nonCommandEditable = true;
 		if(typeof options.unknownCommandResponse === 'undefined') options.unknownCommandResponse = true;
+		if(typeof options.unhandledErrorResponse === 'undefined') options.unhandledErrorResponse = true;
 		super(options);
 
 		/**

--- a/src/commands/message.js
+++ b/src/commands/message.js
@@ -237,7 +237,7 @@ class CommandMessage {
 			if(this.message.channel.typingCount > typingCount) this.message.channel.stopTyping();
 			if(err instanceof FriendlyError) {
 				return this.reply(err.message);
-			} else {
+			} else if(this.client.unhandledErrorResponse) {
 				const owners = this.client.owners;
 				let ownerList = owners ? owners.map((usr, i) => {
 					const or = i === owners.length - 1 && owners.length > 1 ? 'or ' : '';
@@ -250,6 +250,8 @@ class CommandMessage {
 					You shouldn't ever receive an error like this.
 					Please contact ${ownerList || 'the bot owner'}${invite ? ` in this server: ${invite}` : '.'}
 				`);
+			} else {
+				return Promise.resolve(null);
 			}
 		}
 	}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -442,6 +442,7 @@ declare module 'discord.js-commando' {
 		commandEditableDuration?: number;
 		nonCommandEditable?: boolean;
 		unknownCommandResponse?: boolean;
+		unhandledErrorResponse?: boolean;
 		owner?: string | string[] | Set<string>;
 		invite?: string;
 	};


### PR DESCRIPTION
This is in regards to #145. Adds additional parameter to CommandoClient options: unhandledErrorResponse

To ensure backwards compatibility, this defaults to true. If unhandledErrorResponse is set to false, a message will return null (no response) if an unhandled error occurs, and allows the commandError emit event to handle the unhandled error.