### PR TITLE
[Bug] Fix enable command error output

### DIFF
--- a/src/commands/commands/enable.js
+++ b/src/commands/commands/enable.js
@@ -37,14 +37,18 @@ module.exports = class EnableCommandCommand extends Command {
 		if(args.cmdOrGrp.isEnabledIn(msg.guild, true)) {
 			return msg.reply(
 				`The \`${args.cmdOrGrp.name}\` ${args.cmdOrGrp.group ? 'command' : 'group'} is already enabled${
-					group && !group.isEnabledIn(msg.guild) ? `, but the \`${group.name}\` group is disabled, so it still can't be used` : ''
+					group && !group.isEnabledIn(msg.guild) ?
+					`, but the \`${group.name}\` group is disabled, so it still can't be used` :
+					''
 				}.`
 			);
 		}
 		args.cmdOrGrp.setEnabledIn(msg.guild, true);
 		return msg.reply(
 			`Enabled the \`${args.cmdOrGrp.name}\` ${group ? 'command' : 'group'}${
-				group && !group.isEnabledIn(msg.guild) ? `, but the \`${group.name}\` group is disabled, so it still can't be used` : ''
+				group && !group.isEnabledIn(msg.guild) ?
+				`, but the \`${group.name}\` group is disabled, so it still can't be used` :
+				''
 			}.`
 		);
 	}

--- a/src/commands/commands/enable.js
+++ b/src/commands/commands/enable.js
@@ -37,14 +37,14 @@ module.exports = class EnableCommandCommand extends Command {
 		if(args.cmdOrGrp.isEnabledIn(msg.guild, true)) {
 			return msg.reply(
 				`The \`${args.cmdOrGrp.name}\` ${args.cmdOrGrp.group ? 'command' : 'group'} is already enabled${
-					group && !group.enabled ? `, but the \`${group.name}\` group is disabled, so it still can't be used` : ''
+					group && !group.isEnabledIn(msg.guild) ? `, but the \`${group.name}\` group is disabled, so it still can't be used` : ''
 				}.`
 			);
 		}
 		args.cmdOrGrp.setEnabledIn(msg.guild, true);
 		return msg.reply(
 			`Enabled the \`${args.cmdOrGrp.name}\` ${group ? 'command' : 'group'}${
-				group && !group.enabled ? `, but the \`${group.name}\` group is disabled, so it still can't be used` : ''
+				group && !group.isEnabledIn(msg.guild) ? `, but the \`${group.name}\` group is disabled, so it still can't be used` : ''
 			}.`
 		);
 	}


### PR DESCRIPTION
The enable command was referencing `Group.enabled` which is not a valid property causing the error message of "Enabled the command but the group is disabled" to always trigger. 

This PR fixes this.