### PR TITLE
Apply fix for infinite arg with default

### DIFF
--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -308,7 +308,7 @@ class Argument {
 				if(lc === 'finish') {
 					return {
 						value: results.length > 0 ? results : null,
-						cancelled: results.length > 0 ? null : 'user',
+						cancelled: this.default ? null : results.length > 0 ? null : 'user',
 						prompts,
 						answers
 					};


### PR DESCRIPTION
Previously when having both infinite and default on 1 arg they would conflict. Namely say I have 2 args, one is a boolean and the other optional infinite roles (empty default). In this situation it is expected that `command on` just sets the boolean arg and keeps roles empty. The bot properly prompts if that is correct giving the user `cancel` or `finish` as options and then the issue occurs that this PR aims to fix. Previously when doing `finish` the command would just get canceled due to `user`, but clearly we don't want that since the arg has a default.

I was able to diagnose it down to it cancelling due to user by console logging the `result` const in message.js:

https://github.com/discordjs/Commando/blob/061814a24030f74073b056e9cb05782c2dfa9587/src/commands/message.js#L188-L197

Now I've found a couple of solutions to this and all come down the same line. The other two besides the proposed one are using `results.length === 0` and `results.length >= 0` but neither seemed as appropriate as purposely targeting the default args through `this.default`.


**Reproducible code sample:**
*This is a command that when run on the old code as `test on` will have the bot prompt `cancel` or `finish` then when doing `finish` will cancel. However using the new code this same command will instead console log the `option` and `finished run method` while skipping the `if` statement.*
```js
const {Command} = require('discord.js-commando');

module.exports = class TestCommand extends Command {
  constructor (client) {
    super(client, {
      name: 'test',
      memberName: 'test',
      group: 'repro',
      description: 'Reproduce Command for Commando PR',
      args: [
        {
          key: 'option',
          prompt: 'Boolean value?',
          type: 'boolean'
        },
        {
          key: 'roles',
          prompt: 'The role(s)?',
          type: 'role',
          default: 'none',
          infinite: true
        }
      ]
    });
  }

  run (msg, {option, roles}) {
    if (roles) {
      console.log(roles.map(r => r.id));
    }
  
    console.log(option);

    return console.log('finished run method');
  }
};
```

**Please describe the changes this PR makes and why it should be merged:**


**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.