### PR TITLE
Enable async inhibitors

### DIFF
--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -118,7 +118,7 @@ class CommandDispatcher {
 		// Run the command, or reply with an error
 		let responses;
 		if(cmdMsg) {
-			const inhibited = this.inhibit(cmdMsg);
+			const inhibited = await this.inhibit(cmdMsg);
 
 			if(!inhibited) {
 				if(cmdMsg.command) {
@@ -184,9 +184,9 @@ class CommandDispatcher {
 	 * @return {?Array} [reason, ?response]
 	 * @private
 	 */
-	inhibit(cmdMsg) {
+	async inhibit(cmdMsg) {
 		for(const inhibitor of this.inhibitors) {
-			const inhibited = inhibitor(cmdMsg);
+			const inhibited = await inhibitor(cmdMsg); // eslint-disable-line no-await-in-loop
 			if(inhibited) {
 				this.client.emit('commandBlocked', cmdMsg, inhibited instanceof Array ? inhibited[0] : inhibited);
 				return inhibited instanceof Array ? inhibited : [inhibited, undefined];


### PR DESCRIPTION
This PR allows the use for async inhibitors, since the message parsing and stuff already happens inside the context of an async method, this is a rather small fix.

I'm breaking the guidelines of using await in a loop, but that was a conscious decision in order to preserve previous behavior. I could rewrite the code to call all inhibitors asynchronously at once using `Promise.all` and then iterating over the results, but this would call all inhibitors in a non-guaranteed order, break the sequential nature of the previous behavior, and potentially running code that's not needed if the command got inhibited by the first inhibitor.

If running all inhibitors using `Promise.all` is preferred, let me know and I'll rewrite `Dispatcher.inhibit` to use that.