### PR TITLE
Fix better-sqlite3

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,7 +3,7 @@ declare module 'sqlite' {
 	export interface Statement {}
 }
 
-declare module 'syncsqlite' {
+declare module 'better-sqlite3' {
 	export interface Database {}
 	export interface Statement {}
 }


### PR DESCRIPTION
Commando TypeScript will not currently compile, as there is not a `better-sqlite3` module.