### PR TITLE
Fix type returned by findCommands method

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -463,7 +463,7 @@ class CommandRegistry {
 		if(!searchString) {
 			return message ?
 				Array.from(this.commands.filter(cmd => cmd.isUsable(message)).values()) :
-				this.commands;
+				Array.from(this.commands);
 		}
 
 		// Find all matches


### PR DESCRIPTION
The type returned by [findCommands()](https://discord.js.org/#/docs/commando/master/class/CommandRegistry?scrollTo=findCommands) is described as `Command[]` (`Array<Command>`) in JSDoc
But when executed without arguments it returns `Collection<string, Commnad>`
Because it directly returns CommandRegistry#commands