### PR TITLE
Fixed eval command not splitting base message correctly, and made dispatcher await array of message promises

### DIFF
--- a/src/commands/util/eval.js
+++ b/src/commands/util/eval.js
@@ -62,7 +62,12 @@ module.exports = class EvalCommand extends Command {
 
 		// Prepare for callback time and respond
 		this.hrStart = process.hrtime();
-		return msg.reply(this.makeResultMessages(this.lastResult, hrDiff, args.script));
+		const result = this.makeResultMessages(this.lastResult, hrDiff);
+		if(Array.isArray(result)) {
+			return result.map(item => msg.reply(item));
+		} else {
+			return msg.reply(result);
+		}
 	}
 
 	makeResultMessages(result, hrDiff, input = null) {

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -127,6 +127,7 @@ class CommandDispatcher {
 					} else if(!oldMessage || typeof oldCmdMsg !== 'undefined') {
 						responses = await cmdMsg.run();
 						if(typeof responses === 'undefined') responses = null; // eslint-disable-line max-depth
+						if(Array.isArray(responses)) responses = await Promise.all(responses); // eslint-disable-line max-depth
 					}
 				} else {
 					/**


### PR DESCRIPTION
Previously dispatcher simply accepted an array as an array of already resolved messages. I've added in an `await Promise.all();` in the dispatcher to ensure that all returned messages are actually resolved before proceeding.

Also, I fixed some splitting issues with the eval command not actually splitting the initial result from eval into multiple messages if it's too big to fit into one.