### PR TITLE
Fix isEmpty for infinite argument

### DIFF
--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -375,6 +375,7 @@ class Argument {
 	isEmpty(val, msg) {
 		if(this.emptyChecker) return this.emptyChecker(val, msg, this);
 		if(this.type) return this.type.isEmpty(val, msg, this);
+		if(Array.isArray(val)) return val.length === 0;
 		return !val;
 	}
 

--- a/src/types/base.js
+++ b/src/types/base.js
@@ -59,6 +59,7 @@ class ArgumentType {
 	 * @return {boolean} Whether the value is empty
 	 */
 	isEmpty(val, msg, arg) { // eslint-disable-line no-unused-vars
+		if(Array.isArray(val)) return val.length === 0;
 		return !val;
 	}
 }


### PR DESCRIPTION
Addresses #180.

When the argument is infinite, it's `val` is an Array. "Infinite" values should be considered empty if the array that represents them is empty.

This allows for default values to be used in Infinite arguments, whereas the current behavior is that the empty array is not counted as empty (due to Javascript truthiness), which eventually results in the argument being counted as invalid (the bug described by #180).