### PR TITLE
Add ability to hide cancel part of message

### DIFF
--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -57,10 +57,10 @@ class Argument {
 		this.prompt = info.prompt;
 
 		/**
-		 * Show cancellation message for argument
+		 * Whether the cancellation message is displayed for the command
 		 * @type {boolean}
 		 */
-		this.showCancel = typeof info.showCancel !== 'undefined' ? info.showCancel : true;
+		this.showCancel = 'showCancel' in info ? info.showCancel : true;
 
 		/**
 		 * Error message for when a value is invalid

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -60,7 +60,7 @@ class Argument {
 		 * Whether the cancellation message is displayed for the command
 		 * @type {boolean}
 		 */
-		this.showCancel = 'showCancel' in info ? info.showCancel : true;
+		this.hidePrompt = 'hidePrompt' in info ? info.hidePrompt : false;
 
 		/**
 		 * Error message for when a value is invalid
@@ -174,6 +174,14 @@ class Argument {
 
 		while(!valid || typeof valid === 'string') {
 			/* eslint-disable no-await-in-loop */
+			if(this.hidePrompt) {
+				return {
+					value: '',
+					cancelled: null,
+					prompts,
+					answers
+				};
+			}
 			if(prompts.length >= promptLimit) {
 				return {
 					value: null,
@@ -186,10 +194,10 @@ class Argument {
 			// Prompt the user for a new value
 			prompts.push(await msg.reply(stripIndents`
 				${empty ? this.prompt : valid ? valid : `You provided an invalid ${this.label}. Please try again.`}
-				${this.showCancel ? oneLine`
+				${oneLine`
 					Respond with \`cancel\` to cancel the command.
 					${wait ? `The command will automatically be cancelled in ${this.wait} seconds.` : ''}
-				` : ''}
+				`}
 			`));
 
 			// Get the user's response
@@ -275,18 +283,18 @@ class Argument {
 							"${escaped.length < 1850 ? escaped : '[too long to show]'}".
 							Please try again.
 						`}
-						${this.showCancel ? oneLine`
+						${oneLine`
 							Respond with \`cancel\` to cancel the command, or \`finish\` to finish entry up to this point.
 							${wait ? `The command will automatically be cancelled in ${this.wait} seconds.` : ''}
-						` : ''}
+						`}
 					`));
 				} else if(results.length === 0) {
 					prompts.push(await msg.reply(stripIndents`
 						${this.prompt}
-						${this.showCancel ? oneLine`
+						${oneLine`
 							Respond with \`cancel\` to cancel the command, or \`finish\` to finish entry.
 							${wait ? `The command will automatically be cancelled in ${this.wait} seconds, unless you respond.` : ''}
-						` : ''}
+						`}
 					`));
 				}
 
@@ -396,7 +404,7 @@ class Argument {
 		if(typeof info !== 'object') throw new TypeError('Argument info must be an Object.');
 		if(typeof info.key !== 'string') throw new TypeError('Argument key must be a string.');
 		if(info.label && typeof info.label !== 'string') throw new TypeError('Argument label must be a string.');
-		if(typeof info.prompt !== 'string') throw new TypeError('Argument prompt must be a string.');
+		if(typeof info.prompt !== 'string' && !info.hidePrompt) throw new TypeError('Argument prompt must be a string.');
 		if(info.error && typeof info.error !== 'string') throw new TypeError('Argument error must be a string.');
 		if(info.type && typeof info.type !== 'string') throw new TypeError('Argument type must be a string.');
 		if(info.type && !info.type.includes('|') && !client.registry.types.has(info.type)) {

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -57,6 +57,12 @@ class Argument {
 		this.prompt = info.prompt;
 
 		/**
+		 * Show cancellation message for argument
+		 * @type {boolean}
+		 */
+		this.showCancel = typeof info.showCancel !== 'undefined' ? info.showCancel : true;
+
+		/**
 		 * Error message for when a value is invalid
 		 * @type {?string}
 		 */
@@ -180,10 +186,10 @@ class Argument {
 			// Prompt the user for a new value
 			prompts.push(await msg.reply(stripIndents`
 				${empty ? this.prompt : valid ? valid : `You provided an invalid ${this.label}. Please try again.`}
-				${oneLine`
+				${this.showCancel ? oneLine`
 					Respond with \`cancel\` to cancel the command.
 					${wait ? `The command will automatically be cancelled in ${this.wait} seconds.` : ''}
-				`}
+				`: ''}
 			`));
 
 			// Get the user's response
@@ -269,18 +275,18 @@ class Argument {
 							"${escaped.length < 1850 ? escaped : '[too long to show]'}".
 							Please try again.
 						`}
-						${oneLine`
+						${this.showCancel ? oneLine`
 							Respond with \`cancel\` to cancel the command, or \`finish\` to finish entry up to this point.
 							${wait ? `The command will automatically be cancelled in ${this.wait} seconds.` : ''}
-						`}
+						`: ''}
 					`));
 				} else if(results.length === 0) {
 					prompts.push(await msg.reply(stripIndents`
 						${this.prompt}
-						${oneLine`
+						${this.showCancel ? oneLine`
 							Respond with \`cancel\` to cancel the command, or \`finish\` to finish entry.
 							${wait ? `The command will automatically be cancelled in ${this.wait} seconds, unless you respond.` : ''}
-						`}
+						`: ''}
 					`));
 				}
 

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -189,7 +189,7 @@ class Argument {
 				${this.showCancel ? oneLine`
 					Respond with \`cancel\` to cancel the command.
 					${wait ? `The command will automatically be cancelled in ${this.wait} seconds.` : ''}
-				`: ''}
+				` :  ''}
 			`));
 
 			// Get the user's response
@@ -278,7 +278,7 @@ class Argument {
 						${this.showCancel ? oneLine`
 							Respond with \`cancel\` to cancel the command, or \`finish\` to finish entry up to this point.
 							${wait ? `The command will automatically be cancelled in ${this.wait} seconds.` : ''}
-						`: ''}
+						` :  ''}
 					`));
 				} else if(results.length === 0) {
 					prompts.push(await msg.reply(stripIndents`
@@ -286,7 +286,7 @@ class Argument {
 						${this.showCancel ? oneLine`
 							Respond with \`cancel\` to cancel the command, or \`finish\` to finish entry.
 							${wait ? `The command will automatically be cancelled in ${this.wait} seconds, unless you respond.` : ''}
-						`: ''}
+						` :  ''}
 					`));
 				}
 

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -189,7 +189,7 @@ class Argument {
 				${this.showCancel ? oneLine`
 					Respond with \`cancel\` to cancel the command.
 					${wait ? `The command will automatically be cancelled in ${this.wait} seconds.` : ''}
-				` :  ''}
+				` : ''}
 			`));
 
 			// Get the user's response
@@ -278,7 +278,7 @@ class Argument {
 						${this.showCancel ? oneLine`
 							Respond with \`cancel\` to cancel the command, or \`finish\` to finish entry up to this point.
 							${wait ? `The command will automatically be cancelled in ${this.wait} seconds.` : ''}
-						` :  ''}
+						` : ''}
 					`));
 				} else if(results.length === 0) {
 					prompts.push(await msg.reply(stripIndents`
@@ -286,7 +286,7 @@ class Argument {
 						${this.showCancel ? oneLine`
 							Respond with \`cancel\` to cancel the command, or \`finish\` to finish entry.
 							${wait ? `The command will automatically be cancelled in ${this.wait} seconds, unless you respond.` : ''}
-						` :  ''}
+						` : ''}
 					`));
 				}
 


### PR DESCRIPTION
I'm writing some code to create an additional command trigger for a command, and I wanted to hide the cancellation message, since it doesn't work for this, and is misleading. This pull request works hides the cancel message part. Here is my example code to show it.
```
.on('message', async message => {
    if (message.guild && /^!test /.test(message.content)) {
        const command = client.registry.resolveCommand('fun:test');
        const cm = new CommandMessage(message, command, null, null);
        cm.argString = message.content.replace(/^!test/, '');
        let args = new ArgumentCollector(client, [ { key: 'user', prompt: 'Who would you like to test?', type: 'user', showCancel: false } ], 1);
        let provided = [ message.content.replace(/^!test /, '') ];
        const result = await args.obtain(cm, provided);
        console.log(result)
        ...
    }
})
```