### PR TITLE
Add option to disable default commandBlocked responses

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -34,6 +34,7 @@ class CommandoClient extends discord.Client {
 		if(typeof options.commandEditableDuration === 'undefined') options.commandEditableDuration = 30;
 		if(typeof options.nonCommandEditable === 'undefined') options.nonCommandEditable = true;
 		if(typeof options.unknownCommandResponse === 'undefined') options.unknownCommandResponse = true;
+		options.commandBlockedResponse = {};
 		options.commandBlockedResponse = {
 			guildOnly: options.commandBlockedResponse === 'undefined' ? true :
 				options.commandBlockedResponse.guildOnly === 'undefined' ? true :

--- a/src/client.js
+++ b/src/client.js
@@ -15,6 +15,12 @@ class CommandoClient extends discord.Client {
 	 * @property {number} [commandEditableDuration=30] - Time in seconds that command messages should be editable
 	 * @property {boolean} [nonCommandEditable=true] - Whether messages without commands can be edited to a command
 	 * @property {boolean} [unknownCommandResponse=true] - Whether the bot should respond to an unknown command
+	 * @property {Object} [commandBlockedResponse] - Whether the bot should respond when a command is blocked
+	 * @property {boolean} [commandBlockedResponse.guildOnly=true]
+	 * @property {boolean} [commandBlockedResponse.nsfw=true]
+	 * @property {boolean} [commandBlockedResponse.permission=true]
+	 * @property {boolean} [commandBlockedResponse.clientPermissions=true]
+	 * @property {boolean} [commandBlockedResponse.throttling=true]
 	 * @property {string|string[]|Set<string>} [owner] - ID of the bot owner's Discord user, or multiple IDs
 	 * @property {string} [invite] - Invite URL to the bot's support server
 	 */
@@ -28,6 +34,23 @@ class CommandoClient extends discord.Client {
 		if(typeof options.commandEditableDuration === 'undefined') options.commandEditableDuration = 30;
 		if(typeof options.nonCommandEditable === 'undefined') options.nonCommandEditable = true;
 		if(typeof options.unknownCommandResponse === 'undefined') options.unknownCommandResponse = true;
+		options.commandBlockedResponse = {
+			guildOnly: options.commandBlockedResponse === 'undefined' ? true :
+				options.commandBlockedResponse.guildOnly === 'undefined' ? true :
+					!!options.commandBlockedResponse.guildOnly,
+			nsfw: options.commandBlockedResponse === 'undefined' ? true :
+				options.commandBlockedResponse.nsfw === 'undefined' ? true :
+					!!options.commandBlockedResponse.nsfw,
+			permission: options.commandBlockedResponse === 'undefined' ? true :
+				options.commandBlockedResponse.permission === 'undefined' ? true :
+					!!options.commandBlockedResponse.permission,
+			clientPermissions: options.commandBlockedResponse === 'undefined' ? true :
+				options.commandBlockedResponse.clientPermissions === 'undefined' ? true :
+					!!options.commandBlockedResponse.clientPermissions,
+			throttling: options.commandBlockedResponse === 'undefined' ? true :
+				options.commandBlockedResponse.throttling === 'undefined' ? true :
+					!!options.commandBlockedResponse.throttling
+		};
 		super(options);
 
 		/**

--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -143,20 +143,26 @@ module.exports = Structures.extend('Message', Message => {
 				 * (built-in reasons are `guildOnly`, `nsfw`, `permission`, and `throttling`)
 				 */
 				this.client.emit('commandBlocked', this, 'guildOnly');
-				return this.reply(`The \`${this.command.name}\` command must be used in a server channel.`);
+				if(this.client.options.commandBlockedResponse.guildOnly) {
+					return this.reply(`The \`${this.command.name}\` command must be used in a server channel.`);
+				}
 			}
 
 			if(this.command.nsfw && !this.channel.nsfw) {
 				this.client.emit('commandBlocked', this, 'nsfw');
-				return this.reply(`The \`${this.command.name}\` command can only be used in NSFW channels.`);
+				if(this.client.options.commandBlockedResponse.nsfw) {
+					return this.reply(`The \`${this.command.name}\` command can only be used in NSFW channels.`);
+				}
 			}
 
 			// Ensure the user has permission to use the command
 			const hasPermission = this.command.hasPermission(this);
 			if(!hasPermission || typeof hasPermission === 'string') {
 				this.client.emit('commandBlocked', this, 'permission');
-				if(typeof hasPermission === 'string') return this.reply(hasPermission);
-				else return this.reply(`You do not have permission to use the \`${this.command.name}\` command.`);
+				if(this.client.options.commandBlockedResponse.permission) {
+					if(typeof hasPermission === 'string') return this.reply(hasPermission);
+					else return this.reply(`You do not have permission to use the \`${this.command.name}\` command.`);
+				}
 			}
 
 			// Ensure the client user has the required permissions
@@ -164,15 +170,17 @@ module.exports = Structures.extend('Message', Message => {
 				const missing = this.channel.permissionsFor(this.client.user).missing(this.command.clientPermissions);
 				if(missing.length > 0) {
 					this.client.emit('commandBlocked', this, 'clientPermissions');
-					if(missing.length === 1) {
-						return this.reply(
-							`I need the "${permissions[missing[0]]}" permission for the \`${this.command.name}\` command to work.`
-						);
+					if(this.client.options.commandBlockedResponse.clientPermissions) {
+						if(missing.length === 1) {
+							return this.reply(
+								`I need the "${permissions[missing[0]]}" permission for the \`${this.command.name}\` command to work.`
+							);
+						}
+						return this.reply(oneLine`
+							I need the following permissions for the \`${this.command.name}\` command to work:
+							${missing.map(perm => permissions[perm]).join(', ')}
+						`);
 					}
-					return this.reply(oneLine`
-						I need the following permissions for the \`${this.command.name}\` command to work:
-						${missing.map(perm => permissions[perm]).join(', ')}
-					`);
 				}
 			}
 
@@ -181,9 +189,11 @@ module.exports = Structures.extend('Message', Message => {
 			if(throttle && throttle.usages + 1 > this.command.throttling.usages) {
 				const remaining = (throttle.start + (this.command.throttling.duration * 1000) - Date.now()) / 1000;
 				this.client.emit('commandBlocked', this, 'throttling');
-				return this.reply(
-					`You may not use the \`${this.command.name}\` command again for another ${remaining.toFixed(1)} seconds.`
-				);
+				if(this.client.options.commandBlockedResponse.throttling) {
+					return this.reply(
+						`You may not use the \`${this.command.name}\` command again for another ${remaining.toFixed(1)} seconds.`
+					);
+				}
 			}
 
 			// Figure out the command arguments


### PR DESCRIPTION
This PR adds option to selectively disable default responses for various `commandBlocked` events. Apologies for the unsightly code in `client.js`; ESLint was complaining about the line lengths during the tests.