### PR TITLE
Remove escape-string-regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
 	"types": "./typings/index.d.ts",
 	"dependencies": {
 		"common-tags": "^1.0.0",
-		"escape-string-regexp": "^1.0.0",
 		"require-all": "^3.0.0"
 	},
 	"devDependencies": {

--- a/src/commands/util/eval.js
+++ b/src/commands/util/eval.js
@@ -1,7 +1,7 @@
 const util = require('util');
 const discord = require('discord.js');
 const tags = require('common-tags');
-const escapeRegex = require('escape-string-regexp');
+const { escapeRegex } = require('../util');
 const Command = require('../base');
 
 const nl = '!!NL!!';

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -1,4 +1,4 @@
-const escapeRegex = require('escape-string-regexp');
+const { escapeRegex } = require('./util');
 
 /** Handles parsing messages and running commands from them */
 class CommandDispatcher {

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,7 @@
+function escapeRegex(str) {
+	return str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+}
+
 function disambiguation(items, label, property = 'name') {
 	const itemList = items.map(item => `"${(property ? item[property] : item).replace(/ /g, '\xa0')}"`).join(',   ');
 	return `Multiple ${label} found, please be more specific: ${itemList}`;
@@ -48,6 +52,7 @@ const permissions = {
 };
 
 module.exports = {
+	escapeRegex,
 	disambiguation,
 	paginate,
 	permissions


### PR DESCRIPTION
Removes `escape-string-regexp` and replaces it with a one-line function. It's only used twice anyway.