### PR TITLE
fix(Command): ignore args array if empty

### DIFF
--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -52,7 +52,7 @@ class Command {
 	 * @param {CommandoClient} client - The client the command is for
 	 * @param {CommandInfo} info - The command information
 	 */
-	constructor(client, info) {
+	constructor(client, info) { // eslint-disable-line complexity
 		this.constructor.validateInfo(client, info);
 
 		/**
@@ -169,7 +169,9 @@ class Command {
 		 * The argument collector for the command
 		 * @type {?ArgumentCollector}
 		 */
-		this.argsCollector = info.args ? new ArgumentCollector(client, info.args, info.argsPromptLimit) : null;
+		this.argsCollector = info.args && info.args.length ?
+			new ArgumentCollector(client, info.args, info.argsPromptLimit) :
+			null;
 		if(this.argsCollector && typeof info.format === 'undefined') {
 			this.format = this.argsCollector.args.reduce((prev, arg) => {
 				const wrapL = arg.default !== null ? '[' : '<';


### PR DESCRIPTION
> Bug found while troubleshooting that issue with `ndr3w221#6621 (408953935223717898)` in our `#commando` channel.

---
### Issue

Passing an empty args array to `Command`'s constructor as part of the `CommandInfo` results in the following error when running the command:
```
TypeError: Cannot read property 'infinite' of undefined
message.js:197
    at CommandoMessage.run (\discord.js-commando\src\extensions\message.js:195:44)
    at CommandDispatcher.handleMessage (\discord.js-commando\src\dispatcher.js:127:32)
    at CommandoClient.on.message (\discord.js-commando\src\client.js:66:51)
    at CommandoClient.emit (events.js:182:13)
    [...djs stuff]
```
### Explanation

This is because it's trying to check whether the last argument is "infinite", and can't access the last entry's properties of an empty array.
Which is in preparation to prompt for arguments, while there is nothing to prompt.
https://github.com/discordjs/Commando/blob/f844d021d637f9e1e261d7119d52cf2478946aa9/src/extensions/message.js#L191-L196

### Solution

One possible solution for this is treating the empty array as omitted, causing Commando to fallback to [`CommandMessage#parseArgs`](https://github.com/discordjs/Commando/blob/master/src/extensions/message.js#L206).
This is what this PR does.