### PR TITLE
Fix incorrect voiceStateUpdate typings interfering with discord.js master

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -284,7 +284,7 @@ declare module 'discord.js-commando' {
 		on(event: 'typingStop', listener: (channel: Channel, user: User) => void): this;
 		on(event: 'userNoteUpdate', listener: (user: UserResolvable, oldNote: string, newNote: string) => void): this;
 		on(event: 'userUpdate', listener: (oldUser: User, newUser: User) => void): this;
-		on(event: 'voiceStateUpdate', listener: (oldMember: VoiceState | undefined, newMember: VoiceState) => void): this;
+		on(event: 'voiceStateUpdate', listener: (oldState: VoiceState | undefined, newState: VoiceState) => void): this;
 		on(event: 'warn', listener: (info: string) => void): this;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -284,7 +284,7 @@ declare module 'discord.js-commando' {
 		on(event: 'typingStop', listener: (channel: Channel, user: User) => void): this;
 		on(event: 'userNoteUpdate', listener: (user: UserResolvable, oldNote: string, newNote: string) => void): this;
 		on(event: 'userUpdate', listener: (oldUser: User, newUser: User) => void): this;
-		on(event: 'voiceStateUpdate', listener: (oldMember: VoiceState, newMember: VoiceState) => void): this;
+		on(event: 'voiceStateUpdate', listener: (oldMember: VoiceState | undefined, newMember: VoiceState) => void): this;
 		on(event: 'warn', listener: (info: string) => void): this;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,7 +9,7 @@ declare module 'better-sqlite3' {
 }
 
 declare module 'discord.js-commando' {
-	import { Channel, Client, ClientOptions, Collection, DMChannel, Emoji, GroupDMChannel, Guild, GuildChannel, GuildMember, GuildResolvable, Message, MessageAttachment, MessageEmbed, MessageMentions, MessageOptions, MessageReaction, PermissionResolvable, PermissionString, ReactionEmoji, Role, Snowflake, StringResolvable, TextChannel, User, UserResolvable, Webhook } from 'discord.js';
+	import { Channel, Client, ClientOptions, Collection, DMChannel, Emoji, GroupDMChannel, Guild, GuildChannel, GuildMember, GuildResolvable, Message, MessageAttachment, MessageEmbed, MessageMentions, MessageOptions, MessageReaction, PermissionResolvable, PermissionString, ReactionEmoji, Role, Snowflake, StringResolvable, TextChannel, User, UserResolvable, VoiceState, Webhook } from 'discord.js';
 	import { Database as SQLiteDatabase, Statement as SQLiteStatement } from 'sqlite';
 	import { Database as SyncSQLiteDatabase, Statement as SyncSQLiteStatement } from 'better-sqlite3';
 
@@ -283,7 +283,7 @@ declare module 'discord.js-commando' {
 		on(event: 'typingStop', listener: (channel: Channel, user: User) => void): this;
 		on(event: 'userNoteUpdate', listener: (user: UserResolvable, oldNote: string, newNote: string) => void): this;
 		on(event: 'userUpdate', listener: (oldUser: User, newUser: User) => void): this;
-		on(event: 'voiceStateUpdate', listener: (oldMember: GuildMember, newMember: GuildMember) => void): this;
+		on(event: 'voiceStateUpdate', listener: (oldMember: VoiceState, newMember: VoiceState) => void): this;
 		on(event: 'warn', listener: (info: string) => void): this;
 	}
 


### PR DESCRIPTION
Master uses `VoiceState`s instead of `GuildMember`s now.