### PR TITLE
Fix for using RequireAllOptions

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -188,6 +188,7 @@ class CommandoRegistry {
 			}
 		}
 		if(typeof options === 'string' && !this.commandsPath) this.commandsPath = options;
+		else if(typeof options === 'object' && !this.commandsPath) this.commandsPath = options.dirname;
 		return this.registerCommands(commands, true);
 	}
 


### PR DESCRIPTION
Previously when supplying RequireAllOptions rather than a string this would break as it would not be able to resolve the commandPath for storing it.

In the grand scheme of things this allows users to properly provide RequireAllOptions instead of a string to `registerCommandsIn()` function, for example they could use the `filter` function from Require-All

This was shortly mentioned on Discord in a longer conversation with @iCrawl (my Discord name is also Favna)