### PR TITLE
Fix reregister case there is command.default

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -352,6 +352,7 @@ class CommandoRegistry {
 	 * @param {Command} oldCommand - Old command
 	 */
 	reregisterCommand(command, oldCommand) {
+		if(typeof command.default === 'function') command = command.default;
 		if(typeof command === 'function') command = new command(this.client); // eslint-disable-line new-cap
 		if(command.name !== oldCommand.name) throw new Error('Command name cannot change.');
 		if(command.groupID !== oldCommand.groupID) throw new Error('Command group cannot change.');


### PR DESCRIPTION
Previously when the command was nested in a `default` in `reregisterCommand()` the function would fail since `typeof command === 'function'` would resolve to false. This resolves this issue by using the code that was previously already being used in `registerCommandsIn()` to check if `default` exists and if it does rewrites the param.

This was shortly discussed with @iCrawl on Discord, to which he said:

`
the reregisterCommand kind of makes sense because also in registerCommandsIn and registerCommands we do check for default export
`