### PR TITLE
Feature: Improve oneOf on primitive types

### DIFF
--- a/src/types/float.js
+++ b/src/types/float.js
@@ -9,7 +9,7 @@ class FloatArgumentType extends ArgumentType {
 		const float = Number.parseFloat(val);
 		if(Number.isNaN(float)) return false;
 		if(arg.oneOf && !arg.oneOf.includes(float)) {
-			return `Please enter one of ${arg.oneOf.map(opt => `\`${opt}\``).join(', ')}`;
+			return `Please enter one of the following options: ${arg.oneOf.map(opt => `\`${opt}\``).join(', ')}`;
 		}
 		if(arg.min !== null && typeof arg.min !== 'undefined' && float < arg.min) {
 			return `Please enter a number above or exactly ${arg.min}.`;

--- a/src/types/float.js
+++ b/src/types/float.js
@@ -8,7 +8,9 @@ class FloatArgumentType extends ArgumentType {
 	validate(val, msg, arg) {
 		const float = Number.parseFloat(val);
 		if(Number.isNaN(float)) return false;
-		if(arg.oneOf && !arg.oneOf.includes(float)) return false;
+		if(arg.oneOf && !arg.oneOf.includes(float)) {
+			return `Please enter one of ${arg.oneOf.map(opt => `\`${opt}\``).join(', ')}`;
+		}
 		if(arg.min !== null && typeof arg.min !== 'undefined' && float < arg.min) {
 			return `Please enter a number above or exactly ${arg.min}.`;
 		}

--- a/src/types/integer.js
+++ b/src/types/integer.js
@@ -8,7 +8,9 @@ class IntegerArgumentType extends ArgumentType {
 	validate(val, msg, arg) {
 		const int = Number.parseInt(val);
 		if(Number.isNaN(int)) return false;
-		if(arg.oneOf && !arg.oneOf.includes(int)) return false;
+		if(arg.oneOf && !arg.oneOf.includes(int)) {
+			return `Please enter one of ${arg.oneOf.map(opt => `\`${opt}\``).join(', ')}`;
+		}
 		if(arg.min !== null && typeof arg.min !== 'undefined' && int < arg.min) {
 			return `Please enter a number above or exactly ${arg.min}.`;
 		}

--- a/src/types/integer.js
+++ b/src/types/integer.js
@@ -9,7 +9,7 @@ class IntegerArgumentType extends ArgumentType {
 		const int = Number.parseInt(val);
 		if(Number.isNaN(int)) return false;
 		if(arg.oneOf && !arg.oneOf.includes(int)) {
-			return `Please enter one of ${arg.oneOf.map(opt => `\`${opt}\``).join(', ')}`;
+			return `Please enter one of the following options: ${arg.oneOf.map(opt => `\`${opt}\``).join(', ')}`;
 		}
 		if(arg.min !== null && typeof arg.min !== 'undefined' && int < arg.min) {
 			return `Please enter a number above or exactly ${arg.min}.`;

--- a/src/types/string.js
+++ b/src/types/string.js
@@ -7,7 +7,7 @@ class StringArgumentType extends ArgumentType {
 
 	validate(val, msg, arg) {
 		if(arg.oneOf && !arg.oneOf.includes(val.toLowerCase())) {
-			return `Please enter one of ${arg.oneOf.map(opt => `\`${opt}\``).join(', ')}`;
+			return `Please enter one of the following options: ${arg.oneOf.map(opt => `\`${opt}\``).join(', ')}`;
 		}
 		if(arg.min !== null && typeof arg.min !== 'undefined' && val.length < arg.min) {
 			return `Please keep the ${arg.label} above or exactly ${arg.min} characters.`;

--- a/src/types/string.js
+++ b/src/types/string.js
@@ -6,7 +6,9 @@ class StringArgumentType extends ArgumentType {
 	}
 
 	validate(val, msg, arg) {
-		if(arg.oneOf && !arg.oneOf.includes(val.toLowerCase())) return false;
+		if(arg.oneOf && !arg.oneOf.includes(val.toLowerCase())) {
+			return `Please enter one of ${arg.oneOf.map(opt => `\`${opt}\``).join(', ')}`;
+		}
 		if(arg.min !== null && typeof arg.min !== 'undefined' && val.length < arg.min) {
 			return `Please keep the ${arg.label} above or exactly ${arg.min} characters.`;
 		}


### PR DESCRIPTION
Instead of just returning the default error it would be better if we tell users what they *can* fill in. This commit implements this feature.

Example where `oneOf: [1, 2, 3]` is being used:

![image](https://user-images.githubusercontent.com/4019718/49685845-afe3ca80-faeb-11e8-809b-dcc6a83cdb8a.png)

Code to reproduce:

```js
module.exports = class ExampleCommand extends Command {
  constructor (client) {
    super(client, {
      name: 'example',
      memberName: 'example',
      group: 'example',
      description: 'Example command to reproduce PR',
      args: [
        {
          key: 'number',
          prompt: 'What number to input?',
          type: 'integer',
          oneOf: [1, 2, 3]
        }
      ]
    });
  }

  run (msg, {number}) {
    return msg.say(`you picked ${number}`);
  }
};
```