### PR TITLE
fix(eval): fix escapeRegex require path

### DIFF
--- a/src/commands/util/eval.js
+++ b/src/commands/util/eval.js
@@ -1,7 +1,7 @@
 const util = require('util');
 const discord = require('discord.js');
 const tags = require('common-tags');
-const { escapeRegex } = require('../util');
+const { escapeRegex } = require('../../util');
 const Command = require('../base');
 
 const nl = '!!NL!!';


### PR DESCRIPTION
This PR fixes the require path for the `escapeRegex` function, as reported via #230.