### PR TITLE
Allow types to be imported from exports.default

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -203,7 +203,11 @@ class CommandoRegistry {
 	 * @see {@link CommandoRegistry#registerTypes}
 	 */
 	registerType(type) {
-		if(typeof type === 'function') type = new type(this.client); // eslint-disable-line new-cap
+		/* eslint-disable new-cap */
+		if(typeof type === 'function') type = new type(this.client);
+		else if(typeof type.default === 'function') type = new type.default(this.client);
+		/* eslint-enable new-cap */
+
 		if(!(type instanceof ArgumentType)) throw new Error(`Invalid type object to register: ${type}`);
 
 		// Make sure there aren't any conflicts


### PR DESCRIPTION
Typescript compilations cause default classes to be exported on exports.default. The equivalent function for commands `CommandoRegistry.registerCommand()` already handles this so I mirrored the functionality for types.

https://github.com/discordjs/Commando/blob/1039e50082528ed1de11e40cdc340b044b2a8165/src/registry.js#L119-L123