### PR TITLE
Fix registerCommands/registerTypes not accepting ESModules

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -237,7 +237,8 @@ class CommandoRegistry {
 	registerTypes(types, ignoreInvalid = false) {
 		if(!Array.isArray(types)) throw new TypeError('Types must be an Array.');
 		for(const type of types) {
-			if(ignoreInvalid && typeof type !== 'function' && !(type instanceof ArgumentType)) {
+			if(ignoreInvalid && typeof type !== 'function' && typeof type.default !== 'function' &&
+			!(type instanceof ArgumentType)) {
 				this.client.emit('warn', `Attempting to register an invalid argument type object: ${type}; skipping.`);
 				continue;
 			}

--- a/src/registry.js
+++ b/src/registry.js
@@ -165,7 +165,8 @@ class CommandoRegistry {
 	registerCommands(commands, ignoreInvalid = false) {
 		if(!Array.isArray(commands)) throw new TypeError('Commands must be an Array.');
 		for(const command of commands) {
-			if(ignoreInvalid && typeof command !== 'function' && !(command instanceof Command)) {
+			if(ignoreInvalid && typeof command !== 'function' && typeof command.default !== 'function' &&
+			!(command instanceof Command)) {
 				this.client.emit('warn', `Attempting to register an invalid command object: ${command}; skipping.`);
 				continue;
 			}

--- a/src/registry.js
+++ b/src/registry.js
@@ -236,12 +236,7 @@ class CommandoRegistry {
 	 */
 	registerTypes(types, ignoreInvalid = false) {
 		if(!Array.isArray(types)) throw new TypeError('Types must be an Array.');
-		for(let type of types) {
-			/* eslint-disable new-cap */
-			if(typeof type === 'function') type = new type(this.client);
-			else if(typeof type.default === 'function') type = new type.default(this.client);
-			/* eslint-enable new-cap */
-
+		for(const type of types) {
 			if(ignoreInvalid && typeof type !== 'function' && !(type instanceof ArgumentType)) {
 				this.client.emit('warn', `Attempting to register an invalid argument type object: ${type}; skipping.`);
 				continue;

--- a/src/registry.js
+++ b/src/registry.js
@@ -236,7 +236,12 @@ class CommandoRegistry {
 	 */
 	registerTypes(types, ignoreInvalid = false) {
 		if(!Array.isArray(types)) throw new TypeError('Types must be an Array.');
-		for(const type of types) {
+		for(let type of types) {
+			/* eslint-disable new-cap */
+			if(typeof type === 'function') type = new type(this.client);
+			else if(typeof type.default === 'function') type = new type.default(this.client);
+			/* eslint-enable new-cap */
+
 			if(ignoreInvalid && typeof type !== 'function' && !(type instanceof ArgumentType)) {
 				this.client.emit('warn', `Attempting to register an invalid argument type object: ${type}; skipping.`);
 				continue;

--- a/src/registry.js
+++ b/src/registry.js
@@ -165,8 +165,9 @@ class CommandoRegistry {
 	registerCommands(commands, ignoreInvalid = false) {
 		if(!Array.isArray(commands)) throw new TypeError('Commands must be an Array.');
 		for(const command of commands) {
-			if(ignoreInvalid && typeof command !== 'function' && typeof command.default !== 'function' &&
-			!(command instanceof Command)) {
+			const valid = typeof command === 'function' || typeof command.default === 'function ||
+				command instanceof Command || command.default instanceof Command;
+			if(ignoreInvalid && !valid) {
 				this.client.emit('warn', `Attempting to register an invalid command object: ${command}; skipping.`);
 				continue;
 			}
@@ -238,8 +239,9 @@ class CommandoRegistry {
 	registerTypes(types, ignoreInvalid = false) {
 		if(!Array.isArray(types)) throw new TypeError('Types must be an Array.');
 		for(const type of types) {
-			if(ignoreInvalid && typeof type !== 'function' && typeof type.default !== 'function' &&
-			!(type instanceof ArgumentType)) {
+			const valid = typeof type === 'function' || typeof type.default === 'function ||
+				type instanceof ArgumentType || type.default instanceof ArgumentType;
+			if(ignoreInvalid && !valid) {
 				this.client.emit('warn', `Attempting to register an invalid argument type object: ${type}; skipping.`);
 				continue;
 			}

--- a/src/registry.js
+++ b/src/registry.js
@@ -165,7 +165,7 @@ class CommandoRegistry {
 	registerCommands(commands, ignoreInvalid = false) {
 		if(!Array.isArray(commands)) throw new TypeError('Commands must be an Array.');
 		for(const command of commands) {
-			const valid = typeof command === 'function' || typeof command.default === 'function ||
+			const valid = typeof command === 'function' || typeof command.default === 'function' ||
 				command instanceof Command || command.default instanceof Command;
 			if(ignoreInvalid && !valid) {
 				this.client.emit('warn', `Attempting to register an invalid command object: ${command}; skipping.`);
@@ -239,7 +239,7 @@ class CommandoRegistry {
 	registerTypes(types, ignoreInvalid = false) {
 		if(!Array.isArray(types)) throw new TypeError('Types must be an Array.');
 		for(const type of types) {
-			const valid = typeof type === 'function' || typeof type.default === 'function ||
+			const valid = typeof type === 'function' || typeof type.default === 'function' ||
 				type instanceof ArgumentType || type.default instanceof ArgumentType;
 			if(ignoreInvalid && !valid) {
 				this.client.emit('warn', `Attempting to register an invalid argument type object: ${type}; skipping.`);


### PR DESCRIPTION
Previously when a class (extending `ArgumentType`) would be exported with ES6 `export (default)` it would be skipped by the if check because it is inherently not a function, thus causing the second requirement to be true. Naturally this is not expected behaviour and it can be resolved by adding the rewrite code that is also used in other locations such as `registerCommand` and `reregisterCommand`