### PR TITLE
Remove new run method typing added in 905b254

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -110,7 +110,7 @@ declare module 'discord.js-commando' {
 		public onError(err: Error, message: CommandoMessage, args: object | string | string[], fromPattern: false): Promise<Message | Message[]>;
 		public onError(err: Error, message: CommandoMessage, args: string[], fromPattern: true): Promise<Message | Message[]>;
 		public reload(): void;
-		public run(message: CommandoMessage, args: object | string | string[], fromPattern: false): Promise<Message | Message[]>;
+		public run(message: CommandoMessage, args: object | string | string[], fromPattern: boolean): Promise<Message | Message[]>;
 		public setEnabledIn(guild: GuildResolvable, enabled: boolean): void;
 		public unload(): void;
 		public usage(argString?: string, prefix?: string, user?: User): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -111,7 +111,6 @@ declare module 'discord.js-commando' {
 		public onError(err: Error, message: CommandoMessage, args: string[], fromPattern: true): Promise<Message | Message[]>;
 		public reload(): void;
 		public run(message: CommandoMessage, args: object | string | string[], fromPattern: false): Promise<Message | Message[]>;
-		public run(message: CommandoMessage, args: string[], fromPattern: true): Promise<Message | Message[]>;
 		public setEnabledIn(guild: GuildResolvable, enabled: boolean): void;
 		public unload(): void;
 		public usage(argString?: string, prefix?: string, user?: User): string;


### PR DESCRIPTION
I'm not sure what this was meant to do, but it doesn't do it the right way. Whenever creating a command, you can no longer type your args object in the run function, aka:
```js
async run (msg: CommandoMessage, { link }: { link: string | number }): Promise<Message | Message[]>
```
because Array<string> doesn't have a property known as link, but we all know an object is coming through here bruv.

The only way to get it to not error is to explicitly type it as any, which is unacceptable considering TypeScript is all about have some typing in JavaScript.