### PR TITLE
Remove GroupDMChannel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,10 +45,6 @@ module.exports = {
  * @see {@link https://discord.js.org/#/docs/main/master/class/DMChannel}
  */
 /**
- * @external GroupDMChannel
- * @see {@link https://discord.js.org/#/docs/main/master/class/GroupDMChannel}
- */
-/**
  * @external Guild
  * @see {@link https://discord.js.org/#/docs/main/master/class/Guild}
  */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,7 +9,7 @@ declare module 'SyncSqlite' {
 }
 
 declare module 'discord.js-commando' {
-	import { Channel, Client, ClientOptions, Collection, DMChannel, Emoji, GroupDMChannel, Guild, GuildChannel, GuildMember, GuildResolvable, Message, MessageAttachment, MessageEmbed, MessageMentions, MessageOptions, MessageReaction, PermissionResolvable, PermissionString, ReactionEmoji, Role, Snowflake, StringResolvable, TextChannel, User, UserResolvable, VoiceState, Webhook } from 'discord.js';
+	import { Channel, Client, ClientOptions, Collection, DMChannel, Emoji, Guild, GuildChannel, GuildMember, GuildResolvable, Message, MessageAttachment, MessageEmbed, MessageMentions, MessageOptions, MessageReaction, PermissionResolvable, PermissionString, ReactionEmoji, Role, Snowflake, StringResolvable, TextChannel, User, UserResolvable, VoiceState, Webhook } from 'discord.js';
 	import { Database as SQLiteDatabase, Statement as SQLiteStatement } from 'sqlite';
 	import { Database as SyncSQLiteDatabase, Statement as SyncSQLiteStatement } from 'SyncSqlite';
 
@@ -172,7 +172,7 @@ declare module 'discord.js-commando' {
 		public argString: string;
 		public readonly attachments: Collection<string, MessageAttachment>;
 		public readonly author: User;
-		public readonly channel: TextChannel | DMChannel | GroupDMChannel;
+		public readonly channel: TextChannel | DMChannel;
 		public readonly cleanContent: string;
 		public readonly client: CommandoClient;
 		public command: Command;


### PR DESCRIPTION
GroupDMChannels were removed as of https://github.com/discordjs/discord.js/pull/3070/commits/b9f22212444a67a31f7ce75ca99360e17b54fc79.
This PR removes `GroupDMChannel` from the typings along with the jsdoc for it.