### PR TITLE
[Typings] Allow run to return null

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -110,7 +110,7 @@ declare module 'discord.js-commando' {
 		public onError(err: Error, message: CommandoMessage, args: object | string | string[], fromPattern: false): Promise<Message | Message[]>;
 		public onError(err: Error, message: CommandoMessage, args: string[], fromPattern: true): Promise<Message | Message[]>;
 		public reload(): void;
-		public run(message: CommandoMessage, args: object | string | string[], fromPattern: boolean): Promise<Message | Message[]>;
+		public run(message: CommandoMessage, args: object | string | string[], fromPattern: boolean): Promise<Message | Message[] | null> | null;
 		public setEnabledIn(guild: GuildResolvable, enabled: boolean): void;
 		public unload(): void;
 		public usage(argString?: string, prefix?: string, user?: User): string;


### PR DESCRIPTION
Allow run to return null, useful when having to exit out of it returning no message or anything. Should allow both Promised null and normal null to cover async and non-async function. I didn't have issues with this like a week ago then I decided to enable TypeScript's `strict` mode the compiler said "big nope".

I just mentioned this to @Gawdl3y on Discord and he said it had to go to upstream so here's the promised PR.