### PR TITLE
Fix type of ArgumentCollectorResult.values

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -437,8 +437,8 @@ declare module 'discord.js-commando' {
 
 	export const version: string;
 
-	type ArgumentCollectorResult = {
-		values?: object;
+	type ArgumentCollectorResult<T = object> = {
+		values: T | null;
 		cancelled?: 'user' | 'time' | 'promptLimit';
 		prompts: Message[];
 		answers: Message[];


### PR DESCRIPTION
Fix `ArgumentCollectorResult` so that the `values` field is correctly typed as `object | null` instead of `object | undefined`. Also, added an optional generic parameter which allows for more ergonomic usage of `ArgumentCollector.obtain` without the need for type assertions.

https://github.com/discordjs/Commando/blob/master/src/commands/collector.js#L80