### PR TITLE
chore: add `no-var` ESLint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -67,6 +67,7 @@
 		"yoda": "error",
 
 		"no-label-var": "error",
+		"no-var": "error",
 		"no-shadow": "error",
 		"no-undef-init": "error",
 


### PR DESCRIPTION
Since Commando is already `var` free, it makes sense to add this rule in addition to the already existing `no-label-var` rule.