### PR TITLE
Improved typings (ArgumentCollectorResult + others)

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -437,14 +437,14 @@ declare module 'discord.js-commando' {
 
 	export const version: string;
 
-	type ArgumentCollectorResult<T = object> = {
+	export type ArgumentCollectorResult<T = object> = {
 		values: T | null;
 		cancelled?: 'user' | 'time' | 'promptLimit';
 		prompts: Message[];
 		answers: Message[];
 	};
 
-	type ArgumentInfo = {
+	export type ArgumentInfo = {
 		key: string;
 		label?: string;
 		prompt: string;
@@ -461,16 +461,16 @@ declare module 'discord.js-commando' {
 		wait?: number;
 	};
 
-	type ArgumentResult = {
+	export type ArgumentResult = {
 		value: any | any[];
 		cancelled?: 'user' | 'time' | 'promptLimit';
 		prompts: Message[];
 		answers: Message[];
 	};
 
-	type CommandGroupResolvable = CommandGroup | string;
+	export type CommandGroupResolvable = CommandGroup | string;
 
-	type CommandInfo = {
+	export type CommandInfo = {
 		name: string;
 		aliases?: string[];
 		autoAliases?: boolean;
@@ -498,7 +498,7 @@ declare module 'discord.js-commando' {
 		unknown?: boolean;
 	};
 
-	type CommandoClientOptions = ClientOptions & {
+	export type CommandoClientOptions = ClientOptions & {
 		commandPrefix?: string;
 		commandEditableDuration?: number;
 		nonCommandEditable?: boolean;
@@ -506,15 +506,15 @@ declare module 'discord.js-commando' {
 		invite?: string;
 	};
 
-	type CommandResolvable = Command | string;
+	export type CommandResolvable = Command | string;
 
-	type Inhibitor = (msg: CommandoMessage) => false | string | Inhibition;
-	type Inhibition = {
+	export type Inhibitor = (msg: CommandoMessage) => false | string | Inhibition;
+	export type Inhibition = {
 		reason: string;
 		response?: Promise<Message>;
 	}
 
-	type ThrottlingOptions = {
+	export type ThrottlingOptions = {
 		usages: number;
 		duration: number;
 	}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -438,7 +438,7 @@ declare module 'discord.js-commando' {
 	export const version: string;
 
 	export type ArgumentCollectorResult<T extends {} = any> = {
-		values: T extends any ? T : null;
+		values: T extends any ? T : any;
 		cancelled?: 'user' | 'time' | 'promptLimit';
 		prompts: Message[];
 		answers: Message[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -438,7 +438,7 @@ declare module 'discord.js-commando' {
 	export const version: string;
 
 	export type ArgumentCollectorResult<T extends {} = any> = {
-		values: T extends any ? T : any;
+		values: T;
 		cancelled?: 'user' | 'time' | 'promptLimit';
 		prompts: Message[];
 		answers: Message[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -46,7 +46,7 @@ declare module 'discord.js-commando' {
 		public readonly client: CommandoClient;
 		public promptLimit: number;
 
-		public obtain(msg: CommandoMessage, provided?: any[], promptLimit?: number): Promise<ArgumentCollectorResult>;
+		public obtain<T extends {} = any>(msg: CommandoMessage, provided?: any[], promptLimit?: number): Promise<ArgumentCollectorResult<T>>;
 	}
 
 	export class ArgumentType {
@@ -437,8 +437,8 @@ declare module 'discord.js-commando' {
 
 	export const version: string;
 
-	export type ArgumentCollectorResult<T = object> = {
-		values: T | null;
+	export type ArgumentCollectorResult<T extends {} = any> = {
+		values: T extends any ? T : null;
 		cancelled?: 'user' | 'time' | 'promptLimit';
 		prompts: Message[];
 		answers: Message[];


### PR DESCRIPTION
This was brought to my attention when I noticed the recently merged PR #252. While that formed a good start it did optimally use the capabilities of TypeScript. Using the syntax from this PR however that is achieved.

First of all by actually exporting the ArgumentCollectorResult type we can use it in our own code which in itself is a great addition, even without 252. And in fact, 252 is pretty useless without it since the added generic typings weren't being used anywhere. With the addition of this PR however they are.


Adding this PR allows for syntactic sugar such as:


```
type argumentType = {
    types: string;
}

const typeSelection = await typePicker.obtain<argumentType>(command, [], 1);
properties.types = typeSelection.values.types;
```

And through VSCode screenshots it can be shown that now the `argumentType` is inferred all the way down the chain of types:

![image](https://user-images.githubusercontent.com/4019718/55690330-88fdae00-5990-11e9-8247-2ee34d3b6003.png)
![image](https://user-images.githubusercontent.com/4019718/55690334-8e5af880-5990-11e9-851c-6476ac359e78.png)

However when omitting the generic type it will revert to the default of `any`:

![image](https://user-images.githubusercontent.com/4019718/55690338-a0d53200-5990-11e9-8366-50dc29be0b88.png)
![image](https://user-images.githubusercontent.com/4019718/55690339-a5014f80-5990-11e9-8f22-0c1ef7603ea8.png)

Furthermore, to contradict #252 a default of `any` is a must have as otherwise TypeScript will say something like `property types does not exist on type object` even though we theoretically know that whatever key we gave the argument *does* exist on the `ArgumentCollectorResult.values`. 


Lastly the (more advanced) check of `values: T extends any ? T : null;` versus `values: T | null` is to ensure that the TypeScript compiler won't say that `values is potentially undefined` when enabled strict checking / `strictNullChecks`. What the syntax does is that it checks if `T` extends `any` (which it only does when generic T is omitted thus causing it to be `any`), otherwise the type of `values` will be `T`.