### PR TITLE
fix: Support ES6 exports for registerTypesIn.

### DIFF
--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -458,6 +458,8 @@ class Command {
 			}
 		}
 
+		if(typeof newCmd.default === 'function') newCmd = newCmd.default;
+
 		this.client.registry.reregisterCommand(newCmd, this);
 	}
 

--- a/src/registry.js
+++ b/src/registry.js
@@ -260,9 +260,9 @@ class CommandoRegistry {
 	registerTypesIn(options) {
 		const obj = require('require-all')(options);
 		const types = [];
-		for (let type of Object.values(obj)) {
-			if (typeof type.default === 'function') type = type.default
-			types.push(type)
+		for(let type of Object.values(obj)) {
+			if(typeof type.default === 'function') type = type.default;
+			types.push(type);
 		}
 		return this.registerTypes(types, true);
 	}

--- a/src/registry.js
+++ b/src/registry.js
@@ -260,7 +260,10 @@ class CommandoRegistry {
 	registerTypesIn(options) {
 		const obj = require('require-all')(options);
 		const types = [];
-		for(const type of Object.values(obj)) types.push(type);
+		for (let type of Object.values(obj)) {
+			if (typeof type.default === 'function') type = type.default
+			types.push(type)
+		}
 		return this.registerTypes(types, true);
 	}
 


### PR DESCRIPTION
I noticed that while you can use `export default` instead of `module.exports = `  in most places - it doesn't work when using `client.registry.registerTypesIn`. This PR addresses that issue.