### PR TITLE
chore: mark optional peerDependencies as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,17 @@
 		"discord.js": "^12.0.0",
 		"sqlite": "^3.0.0"
 	},
+	"peerDependenciesMeta": {
+		"@types/better-sqlite3": {
+			"optional": true
+		},
+		"better-sqlite3": {
+			"optional": true
+		},
+		"sqlite": {
+			"optional": true
+		}
+	},
 	"engines": {
 		"node": ">=8.6.0"
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

A while ago a RFC was made for yarn to allow marking peer dependencies as optional and with that silencing the warnings about missing peer dependencies. [You can read that RFC here](https://github.com/yarnpkg/rfcs/blob/master/accepted/0000-optional-peer-dependencies.md). This was added in yarn in version 1.13.0 ([PR](https://github.com/yarnpkg/yarn/pull/6671) and pnpm version 3.2.0-1 ([PR](https://github.com/pnpm/pnpm/issues/1486)). Later it was also added to npm in version 6.11.0 ([Changelog](https://github.com/npm/cli/blob/latest/CHANGELOG.md#v6110-2019-08-20))

Since it is now available in all 3 major package managing CLI tools I think this repo should make use of the additional fields in package.json to silence the warnings.

Note: a similar PR has been made to the main discord.js repository: https://github.com/discordjs/discord.js/pull/3511

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.