### PR TITLE
Updated Commando typings to extend Message

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -147,7 +147,7 @@ declare module 'discord.js-commando' {
 		public setEnabledIn(guild: GuildResolvable, enabled: boolean): void;
 	}
 
-	export class CommandoMessage {
+	export class CommandoMessage extends Message {
 		public constructor(message: Message, command?: Command, argString?: string, patternMatches?: string[]);
 
 		private deleteRemainingResponses(): void;


### PR DESCRIPTION
Found it annoying that message.type was giving me error that it did not exists, and found that comandomessage does not extend message, as the documentation suggests.