### PR TITLE
Add new ignoreBotMessages option to CommandoClient.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -14,6 +14,7 @@ class CommandoClient extends discord.Client {
 	 * @property {string} [commandPrefix=!] - Default command prefix
 	 * @property {number} [commandEditableDuration=30] - Time in seconds that command messages should be editable
 	 * @property {boolean} [nonCommandEditable=true] - Whether messages without commands can be edited to a command
+	 * @property {boolean} [ignoreBotMessages=true] - Whether the bot should ignore messages or commands from other bots
 	 * @property {string|string[]|Set<string>} [owner] - ID of the bot owner's Discord user, or multiple IDs
 	 * @property {string} [invite] - Invite URL to the bot's support server
 	 */
@@ -26,6 +27,7 @@ class CommandoClient extends discord.Client {
 		if(options.commandPrefix === null) options.commandPrefix = '';
 		if(typeof options.commandEditableDuration === 'undefined') options.commandEditableDuration = 30;
 		if(typeof options.nonCommandEditable === 'undefined') options.nonCommandEditable = true;
+		if(typeof options.ignoreBotMessages === 'undefined') options.ignoreBotMessages = true;
 		super(options);
 
 		/**

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -173,8 +173,11 @@ class CommandDispatcher {
 		// Ignore partial messages
 		if(message.partial) return false;
 
-		if(message.author.bot) return false;
-		else if(message.author.id === this.client.user.id) return false;
+		// Ignore messages from other bots based on client configuration
+		if(message.author.bot && this.client.options.ignoreBotMessages) return false;
+
+		// Ignore messages from this bot
+		if(message.author.id === this.client.user.id) return false;
 
 		// Ignore messages from users that the bot is already waiting for input from
 		if(this._awaiting.has(message.author.id + message.channel.id)) return false;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -490,6 +490,7 @@ declare module 'discord.js-commando' {
 		commandPrefix?: string;
 		commandEditableDuration?: number;
 		nonCommandEditable?: boolean;
+		ignoreBotMessages?: boolean;
 		owner?: string | string[] | Set<string>;
 		invite?: string;
 	}


### PR DESCRIPTION
Previously, the logic to ignore messages from other bots was hard coded
into dispatcher.js in the shouldHandleMessage function. This change
removes this hard coded logic and makes it configurable via a new
CommandClientOption. The default state for this option is 'true', which
follows current best practice guidelines.