### PR TITLE
Added option for prompted messages to be embedded.

### DIFF
--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -288,7 +288,7 @@ class Argument {
 					`}
 				`;
 					if(this.embed) {
-						await msg.replyEmbed(new MessageEmbed().setDescription(newPromptValue).setColor('RANDOM'));
+						prompts.push(await msg.replyEmbed(new MessageEmbed().setDescription(newPromptValue).setColor('RANDOM')));
 					} else {
 						prompts.push(await msg.reply(newPromptValue));
 					}
@@ -301,7 +301,7 @@ class Argument {
 					`}
 				`;
 					if(this.embed) {
-						await msg.replyEmbed(new MessageEmbed().setDescription(finishPrompt).setColor('RANDOM'));
+						prompts.push(await msg.replyEmbed(new MessageEmbed().setDescription(finishPrompt).setColor('RANDOM')));
 					} else {
 						prompts.push(await msg.reply(finishPrompt));
 					}

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -184,7 +184,7 @@ class Argument {
 			}
 
 			// Prompt the user for a new value
-			this.embed === true ? msg.replyEmbed(new MessageEmbed().setDescription(stripIndents`
+			this.embed === true ? await msg.replyEmbed(new MessageEmbed().setDescription(stripIndents`
 		  ${empty ? this.prompt : valid ? valid : `You provided an invalid ${this.label}. Please try again.`}
 		  ${oneLine`
 			  Respond with \`cancel\` to cancel the command.
@@ -275,7 +275,7 @@ class Argument {
 				// Prompt the user for a new value
 				if(val) {
 					const escaped = escapeMarkdown(val).replace(/@/g, '@\u200b');
-				        this.embed === true ? msg.replyEmbed(new MessageEmbed().setDescription(stripIndents`
+				        this.embed === true ? await msg.replyEmbed(new MessageEmbed().setDescription(stripIndents`
 					${valid ? valid : oneLine`
 						You provided an invalid ${this.label},
 						"${escaped.length < 1850 ? escaped : '[too long to show]'}".
@@ -297,7 +297,7 @@ class Argument {
 						`}
 					`));
 				} else if(results.length === 0) {
-					this.embed === true ? msg.replyEmbed(new MessageEmbed().setDescription(stripIndents`
+					this.embed === true ? await msg.replyEmbed(new MessageEmbed().setDescription(stripIndents`
 					${this.prompt}
 					${oneLine`
 						Respond with \`cancel\` to cancel the command, or \`finish\` to finish entry.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -13,6 +13,7 @@ declare module 'discord.js-commando' {
 		public infinite: boolean;
 		public key: string;
 		public label: string;
+		public embed: boolean;
 		public max: number;
 		public min: number;
 		public oneOf: any[];
@@ -439,6 +440,7 @@ declare module 'discord.js-commando' {
 		error?: string;
 		type?: string;
 		max?: number;
+		embed?: boolean;
 		min?: number;
 		oneOf?: any[];
 		default?: any | Function;


### PR DESCRIPTION
If the **embed** property is set to true prompted messages will be embedded, otherwise the default messages will be returned.

I think this is very nice and i've been using it for a while on my own, but I think other people would like to have this too. I chose to use **replyEmbed** because the default method you're using is **reply** and I thought it'd make sense.