### PR TITLE
Eval can work while script is in a code block

### DIFF
--- a/src/commands/util/eval.js
+++ b/src/commands/util/eval.js
@@ -50,6 +50,11 @@ module.exports = class EvalCommand extends Command {
 		};
 		/* eslint-enable no-unused-vars */
 
+		// Remove any surrounding code blocks before evaluation
+		if(args.script.startsWith('```') && args.script.endsWith('```')) {
+			args.script = args.script.replace(/(^.*?\s)|(\n.*$)/g, '');
+		}
+
 		// Run the code and measure its execution time
 		let hrDiff;
 		try {


### PR DESCRIPTION
I noticed that scripts in codeblocks would not work in `eval` command, but the codeblocks offer syntax highlighting, which can help you find any mistakes you may have written in your script.
![Example](https://user-images.githubusercontent.com/19333607/74721994-6f0a3a00-51f5-11ea-9b9c-cce6623f01df.PNG)
