### PR TITLE
Accept smart quotes

### DIFF
--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -520,8 +520,12 @@ module.exports = Structures.extend('Message', Message => {
 });
 
 function removeSmartQuotes(argString, allowSingleQuote = true) {
-	const quoteReplacementRegex = allowSingleQuote ? /[‘’“”]/g : /[“”]/g;
-	return argString.replace(quoteReplacementRegex, '"');
+	let replacementArgString = argString;
+	const singleSmartQuote = /[‘’]/g;
+	const doubleSmartQuote = /[“”]/g;
+	if(allowSingleQuote) replacementArgString = argString.replace(singleSmartQuote, '\'');
+	return replacementArgString
+	.replace(doubleSmartQuote, '"');
 }
 
 function channelIDOrDM(channel) {

--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -499,7 +499,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * @return {string[]} The array of arguments
 		 */
 		static parseArgs(argString, argCount, allowSingleQuote = true) {
-			const argStringModified = removeSmartQuotes(argString);
+			const argStringModified = removeSmartQuotes(argString, allowSingleQuote);
 			const re = allowSingleQuote ? /\s*(?:("|')([^]*?)\1|(\S+))\s*/g : /\s*(?:(")([^]*?)"|(\S+))\s*/g;
 			const result = [];
 			let match = [];
@@ -519,8 +519,9 @@ module.exports = Structures.extend('Message', Message => {
 	return CommandoMessage;
 });
 
-function removeSmartQuotes(argString) {
-	return argString.replace(/[‘’]/g, '"');
+function removeSmartQuotes(argString, allowSingleQuote = true) {
+	const quoteReplacementRegex = allowSingleQuote ? /[‘’“”]/g : /[“”]/g;
+	return argString.replace(quoteReplacementRegex, '"');
 }
 
 function channelIDOrDM(channel) {

--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -499,17 +499,18 @@ module.exports = Structures.extend('Message', Message => {
 		 * @return {string[]} The array of arguments
 		 */
 		static parseArgs(argString, argCount, allowSingleQuote = true) {
+			const argStringModified = removeSmartQuotes(argString);
 			const re = allowSingleQuote ? /\s*(?:("|')([^]*?)\1|(\S+))\s*/g : /\s*(?:(")([^]*?)"|(\S+))\s*/g;
 			const result = [];
 			let match = [];
 			// Large enough to get all items
-			argCount = argCount || argString.length;
+			argCount = argCount || argStringModified.length;
 			// Get match and push the capture group that is not null to the result
-			while(--argCount && (match = re.exec(argString))) result.push(match[2] || match[3]);
+			while(--argCount && (match = re.exec(argStringModified))) result.push(match[2] || match[3]);
 			// If text remains, push it to the array as-is (except for wrapping quotes, which are removed)
-			if(match && re.lastIndex < argString.length) {
+			if(match && re.lastIndex < argStringModified.length) {
 				const re2 = allowSingleQuote ? /^("|')([^]*)\1$/g : /^(")([^]*)"$/g;
-				result.push(argString.substr(re.lastIndex).replace(re2, '$2'));
+				result.push(argStringModified.substr(re.lastIndex).replace(re2, '$2'));
 			}
 			return result;
 		}
@@ -517,6 +518,10 @@ module.exports = Structures.extend('Message', Message => {
 
 	return CommandoMessage;
 });
+
+function removeSmartQuotes(argString) {
+	return argString.replace(/[‘’]/g, '"');
+}
 
 function channelIDOrDM(channel) {
 	if(channel.type !== 'dm') return channel.id;


### PR DESCRIPTION
I noticed users who tried to use quotes on iPhone to wrap arguments encountered an error. This new function replaces single smart quotes with single quotes and double smart quotes with double quotes in the first line of `parseArgs` before continuing.