### PR TITLE
fix: convert all arguments to lowercase

### DIFF
--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -94,9 +94,7 @@ class Argument {
 		 * If type is `channel`, `member`, `role`, or `user`, this will be the IDs.
 		 * @type {?string[]}
 		 */
-		this.oneOf = typeof info.oneOf !== 'undefined' ?
-			info.oneOf.map(el => el.toLowerCase ? el.toLowerCase() : el) :
-			null;
+		this.oneOf = typeof info.oneOf !== 'undefined' ? info.oneOf.map(x => x.toLowerCase ? x.toLowerCase() : x) : null;
 
 		/**
 		 * Whether the argument accepts an infinite number of values

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -94,7 +94,9 @@ class Argument {
 		 * If type is `channel`, `member`, `role`, or `user`, this will be the IDs.
 		 * @type {?string[]}
 		 */
-		this.oneOf = typeof info.oneOf !== 'undefined' ? info.oneOf.map(el => el.toLowerCase ? el.toLowerCase() : el) : null;
+		this.oneOf = typeof info.oneOf !== 'undefined' ?
+			info.oneOf.map(el => el.toLowerCase ? el.toLowerCase() : el) :
+			null;
 
 		/**
 		 * Whether the argument accepts an infinite number of values

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -94,7 +94,7 @@ class Argument {
 		 * If type is `channel`, `member`, `role`, or `user`, this will be the IDs.
 		 * @type {?string[]}
 		 */
-		this.oneOf = typeof info.oneOf !== 'undefined' ? info.oneOf.map(x => x.toLowerCase ? x.toLowerCase() : x) : null;
+		this.oneOf = typeof info.oneOf !== 'undefined' ? info.oneOf.map(el => el.toLowerCase ? el.toLowerCase() : el) : null;
 
 		/**
 		 * Whether the argument accepts an infinite number of values

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -94,7 +94,7 @@ class Argument {
 		 * If type is `channel`, `member`, `role`, or `user`, this will be the IDs.
 		 * @type {?string[]}
 		 */
-		this.oneOf = typeof info.oneOf !== 'undefined' ? info.oneOf : null;
+		this.oneOf = typeof info.oneOf !== 'undefined' ? info.oneOf.map(x => x.toLowerCase ? x.toLowerCase() : x) : null;
 
 		/**
 		 * Whether the argument accepts an infinite number of values

--- a/src/types/string.js
+++ b/src/types/string.js
@@ -6,7 +6,7 @@ class StringArgumentType extends ArgumentType {
 	}
 
 	validate(val, msg, arg) {
-		if(arg.oneOf && !arg.oneOf.map(ind => ind.toLowerCase ? ind.toLowerCase() : ind).includes(val.toLowerCase()))
+		if(arg.oneOf && !arg.oneOf.includes(val.toLowerCase())) {
 			return `Please enter one of the following options: ${arg.oneOf.map(opt => `\`${opt}\``).join(', ')}`;
 		}
 		if(arg.min !== null && typeof arg.min !== 'undefined' && val.length < arg.min) {

--- a/src/types/string.js
+++ b/src/types/string.js
@@ -6,7 +6,7 @@ class StringArgumentType extends ArgumentType {
 	}
 
 	validate(val, msg, arg) {
-		if(arg.oneOf && !arg.oneOf.map(ind => ind.toLowerCase ? ind.toLowerCase() : ind).includes(val.toLowerCase()))
+		if(arg.oneOf && !arg.oneOf.map(ind => ind.toLowerCase ? ind.toLowerCase() : ind).includes(val.toLowerCase())) {
 			return `Please enter one of the following options: ${arg.oneOf.map(opt => `\`${opt}\``).join(', ')}`;
 		}
 		if(arg.min !== null && typeof arg.min !== 'undefined' && val.length < arg.min) {

--- a/src/types/string.js
+++ b/src/types/string.js
@@ -6,7 +6,7 @@ class StringArgumentType extends ArgumentType {
 	}
 
 	validate(val, msg, arg) {
-		if(arg.oneOf && !arg.oneOf.map(ind => ind.toLowerCase ? ind.toLowerCase() : ind).includes(val.toLowerCase())) {
+		if(arg.oneOf && !arg.oneOf.map(ind => ind.toLowerCase ? ind.toLowerCase() : ind).includes(val.toLowerCase()))
 			return `Please enter one of the following options: ${arg.oneOf.map(opt => `\`${opt}\``).join(', ')}`;
 		}
 		if(arg.min !== null && typeof arg.min !== 'undefined' && val.length < arg.min) {

--- a/src/types/string.js
+++ b/src/types/string.js
@@ -6,7 +6,7 @@ class StringArgumentType extends ArgumentType {
 	}
 
 	validate(val, msg, arg) {
-		if(arg.oneOf && !arg.oneOf.includes(val.toLowerCase())) {
+		if(arg.oneOf && !arg.oneOf.map(ind => ind.toLowerCase ? ind.toLowerCase() : ind).includes(val.toLowerCase()))
 			return `Please enter one of the following options: ${arg.oneOf.map(opt => `\`${opt}\``).join(', ')}`;
 		}
 		if(arg.min !== null && typeof arg.min !== 'undefined' && val.length < arg.min) {


### PR DESCRIPTION
If you're checking the lower-case value is included within an array that may not be lower-case, that's pointless and may result in cases where the condition is never true. For example, you want to match an upper-case string in a string[], but because this checks lower-case, it will _never_ be true.