### PR TITLE
Use is-promise to check if objects are Promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	"types": "./typings/index.d.ts",
 	"dependencies": {
 		"common-tags": "^1.8.0",
+		"is-promise": "^4.0.0",
 		"require-all": "^3.0.0"
 	},
 	"devDependencies": {

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -1,5 +1,6 @@
 const { escapeMarkdown } = require('discord.js');
 const { oneLine, stripIndents } = require('common-tags');
+const isPromise = require('is-promise');
 const ArgumentUnionType = require('../types/union');
 
 /** A fancy argument */
@@ -351,7 +352,7 @@ class Argument {
 	validate(val, msg) {
 		const valid = this.validator ? this.validator(val, msg, this) : this.type.validate(val, msg, this);
 		if(!valid || typeof valid === 'string') return this.error || valid;
-		if(valid instanceof Promise) return valid.then(vld => !vld || typeof vld === 'string' ? this.error || vld : vld);
+		if(isPromise(valid)) return valid.then(vld => !vld || typeof vld === 'string' ? this.error || vld : vld);
 		return valid;
 	}
 

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -1,4 +1,5 @@
 const { escapeRegex } = require('./util');
+const isPromise = require('is-promise');
 
 /** Handles parsing messages and running commands from them */
 class CommandDispatcher {
@@ -200,7 +201,7 @@ class CommandDispatcher {
 				const valid = typeof inhibit.reason === 'string' && (
 					typeof inhibit.response === 'undefined' ||
 					inhibit.response === null ||
-					inhibit.response instanceof Promise
+					isPromise(inhibit.response)
 				);
 				if(!valid) {
 					throw new TypeError(


### PR DESCRIPTION
This adds support for alternative Promise implementations.

In particular, we had seen several cases where our command Inhibitors were producing ugly error messages about invalid return types, even though we are returning what should be a valid value (an object with a string `reason` and a Promise `response` generated by message.reply). For example:

```javascript
        client.dispatcher.addInhibitor(function(message){
            if (message.command && message.command.name === 'set-name' && !TrainManager.isTrainChannel(message.channel.id)) {
                return {reason: 'invalid-channel', response: message.reply('use this command from a train channel.')};
            }
            return false;
        });
```

Switching to use is-promise resolves the issue by correctly handling all `then`ables as Promises, including alternative Promise implementations like Bluebird.