### PR TITLE
fix send shard.broadcastEval in discord v12

### DIFF
--- a/src/commands/commands/load.js
+++ b/src/commands/commands/load.js
@@ -51,7 +51,8 @@ module.exports = class LoadCommandCommand extends Command {
 		if(this.client.shard) {
 			try {
 				await this.client.shard.broadcastEval(`
-					if(this.shard.id !== ${this.client.shard.id}) {
+					const ids = [${this.client.shard.ids.join(',')}];
+					if(!this.shard.ids.some(id => ids.includes(id))) {
 						const cmdPath = this.registry.resolveCommandPath('${command.groupID}', '${command.name}');
 						delete require.cache[cmdPath];
 						this.registry.registerCommand(require(cmdPath));

--- a/src/commands/commands/reload.js
+++ b/src/commands/commands/reload.js
@@ -37,7 +37,8 @@ module.exports = class ReloadCommandCommand extends Command {
 		if(this.client.shard) {
 			try {
 				await this.client.shard.broadcastEval(`
-					if(this.shard.id !== ${this.client.shard.id}) {
+					const ids = [${this.client.shard.ids.join(',')}];
+					if(!this.shard.ids.some(id => ids.includes(id))) {
 						this.registry.${isCmd ? 'commands' : 'groups'}.get('${isCmd ? cmdOrGrp.name : cmdOrGrp.id}').reload();
 					}
 				`);

--- a/src/commands/commands/unload.js
+++ b/src/commands/commands/unload.js
@@ -33,7 +33,10 @@ module.exports = class UnloadCommandCommand extends Command {
 		if(this.client.shard) {
 			try {
 				await this.client.shard.broadcastEval(`
-					if(this.shard.id !== ${this.client.shard.id}) this.registry.commands.get('${args.command.name}').unload();
+					const ids = [${this.client.shard.ids.join(',')}];
+					if(!this.shard.ids.some(id => ids.includes(id))) {
+						this.registry.commands.get('${args.command.name}').unload();
+					}
 				`);
 			} catch(err) {
 				this.client.emit('warn', `Error when broadcasting command unload to other shards`);

--- a/src/providers/sqlite-sync.js
+++ b/src/providers/sqlite-sync.js
@@ -224,7 +224,8 @@ class SyncSQLiteProvider extends SettingProvider {
 		key = JSON.stringify(key);
 		val = typeof val !== 'undefined' ? JSON.stringify(val) : 'undefined';
 		this.client.shard.broadcastEval(`
-			if(this.shard.id !== ${this.client.shard.id} && this.provider && this.provider.settings) {
+			const ids = [${this.client.shard.ids.join(',')}];
+			if(!this.shard.ids.some(id => ids.includes(id)) && this.provider && this.provider.settings) {
 				let global = this.provider.settings.get('global');
 				if(!global) {
 					global = {};

--- a/src/providers/sqlite.js
+++ b/src/providers/sqlite.js
@@ -234,7 +234,8 @@ class SQLiteProvider extends SettingProvider {
 		key = JSON.stringify(key);
 		val = typeof val !== 'undefined' ? JSON.stringify(val) : 'undefined';
 		this.client.shard.broadcastEval(`
-			if(this.shard.id !== ${this.client.shard.id} && this.provider && this.provider.settings) {
+			const ids = [${this.client.shard.ids.join(',')}];
+			if(!this.shard.ids.some(id => ids.includes(id)) && this.provider && this.provider.settings) {
 				let global = this.provider.settings.get('global');
 				if(!global) {
 					global = {};


### PR DESCRIPTION
In discord v12 `client.shard.id` change to client.shard.ids.
So it need to change to reload command in another shards