### PR TITLE
fix: voice channel args type not working with id

### DIFF
--- a/src/types/voice-channel.js
+++ b/src/types/voice-channel.js
@@ -11,7 +11,7 @@ class VoiceChannelArgumentType extends ArgumentType {
 		const matches = val.match(/^([0-9]+)$/);
 		if(matches) {
 			try {
-				const channel = msg.client.channels.cache.resolve(matches[1]);
+				const channel = msg.client.channels.resolve(matches[1]);
 				if(!channel || channel.type !== 'voice') return false;
 				if(arg.oneOf && !arg.oneOf.includes(channel.id)) return false;
 				return true;


### PR DESCRIPTION
If you have a voice-channel as a args type, you can't enter a voice channel id, because of:
```js
TypeError: msg.client.channels.cache.resolve is not a function
```
old code:
```js
const channel = msg.client.channels.cache.resolve(matches[1]);
```
but ``channels.cache.resolve`` is wrong, you need to use ``channels.resolve``