### PR TITLE
Mention prefix

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -16,6 +16,7 @@ class CommandoClient extends discord.Client {
 	 * @property {boolean} [nonCommandEditable=true] - Whether messages without commands can be edited to a command
 	 * @property {string|string[]|Set<string>} [owner] - ID of the bot owner's Discord user, or multiple IDs
 	 * @property {string} [invite] - Invite URL to the bot's support server
+	 * @property {boolean} [mentionPrefix=true] Enable whether the bot mention, should also be a command prefix.
 	 */
 
 	/**
@@ -26,6 +27,7 @@ class CommandoClient extends discord.Client {
 		if(options.commandPrefix === null) options.commandPrefix = '';
 		if(typeof options.commandEditableDuration === 'undefined') options.commandEditableDuration = 30;
 		if(typeof options.nonCommandEditable === 'undefined') options.nonCommandEditable = true;
+		if(options.mentionPrefix === null) options.mentionPrefix = true;
 		super(options);
 
 		/**
@@ -164,6 +166,15 @@ class CommandoClient extends discord.Client {
 		this.emit('providerReady', provider);
 		this.emit('debug', 'Provider finished initialisation.');
 		return undefined;
+	}
+
+	get mentionPrefix() {
+		if(!this.options.mentionPrefix) return null;
+		return this.options.mentionPrefix;
+	}
+
+	set mentionPrefix(value) {
+		this.options.mentionPrefix = value;
 	}
 
 	async destroy() {

--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -476,9 +476,10 @@ class Command {
 	 * @param {string} command - A command + arg string
 	 * @param {string} [prefix] - Prefix to use for the prefixed command format
 	 * @param {User} [user] - User to use for the mention command format
+	 * @param {boolean} [mentionPrefix] - Value, wether or not mention as prefix is enabled.
 	 * @return {string}
 	 */
-	static usage(command, prefix = null, user = null) {
+	static usage(command, prefix = null, user = null, mentionPrefix = null) {
 		const nbcmd = command.replace(/ /g, '\xa0');
 		if(!prefix && !user) return `\`\`${nbcmd}\`\``;
 
@@ -490,9 +491,11 @@ class Command {
 		}
 
 		let mentionPart;
-		if(user) mentionPart = `\`\`@${user.username.replace(/ /g, '\xa0')}#${user.discriminator}\xa0${nbcmd}\`\``;
+		if(user && mentionPrefix) {
+			mentionPart = `\`\`@${user.username.replace(/ /g, '\xa0')}#${user.discriminator}\xa0${nbcmd}\`\``;
+		}
 
-		return `${prefixPart || ''}${prefix && user ? ' or ' : ''}${mentionPart || ''}`;
+		return `${prefixPart || ''}${prefix && user && mentionPrefix ? ' or ' : ''}${mentionPart || ''}`;
 	}
 
 	/**

--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -95,7 +95,7 @@ module.exports = Structures.extend('Message', Message => {
 				if(this.guild) prefix = this.guild.commandPrefix;
 				else prefix = this.client.commandPrefix;
 			}
-			return Command.usage(command, prefix, user);
+			return Command.usage(command, prefix, user, this.client.mentionPrefix);
 		}
 
 		/**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -103,7 +103,7 @@ declare module 'discord.js-commando' {
 		public unload(): void;
 		public usage(argString?: string, prefix?: string, user?: User): string;
 
-		public static usage(command: string, prefix?: string, user?: User): string;
+		public static usage(command: string, prefix?: string, user?: User, mentionPrefix?: boolean): string;
 	}
 
 	export class CommandDispatcher {
@@ -113,7 +113,7 @@ declare module 'discord.js-commando' {
 		private _commandPatterns: object;
 		private _results: Map<string, CommandoMessage>;
 
-		private buildCommandPattern(prefix: string): RegExp;
+		private buildCommandPattern(prefix: string, mentionPrefix: boolean): RegExp;
 		private cacheCommandoMessage(message: Message, oldMessage: Message, cmdMsg: CommandoMessage, responses: Message | Message[]): void;
 		private handleMessage(messge: Message, oldMessage?: Message): Promise<void>;
 		private inhibit(cmdMsg: CommandoMessage): Inhibition;
@@ -223,6 +223,7 @@ declare module 'discord.js-commando' {
 		public provider: SettingProvider;
 		public registry: CommandoRegistry;
 		public settings: GuildSettingsHelper;
+		public mentionPrefix: boolean;
 
 		public isOwner(user: UserResolvable): boolean;
 		public setProvider(provider: SettingProvider | Promise<SettingProvider>): Promise<void>;


### PR DESCRIPTION
I checked out the repo, and saw in the Discord.js guide, that it's not possible, to disable the mention prefix.
So I decided to make it availabe to pass it as a setting, to the CommandoClient settings.
If accepted, someone else or me at another point, could work it out, to be guild based, and not only global.
But the option, to enable/disable is better than no option at all.
