### PR TITLE
Added CommandDispatcher as a default export.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ module.exports = {
 	Client: require('./client'),
 	CommandoClient: require('./client'),
 	CommandoRegistry: require('./registry'),
+	CommandDispatcher: require('./dispatcher'),
 	CommandoGuild: require('./extensions/guild'),
 	CommandoMessage: require('./extensions/message'),
 	Command: require('./commands/base'),


### PR DESCRIPTION
A PR for #348 
Really not much too it, other than adding the CommandDispatcher as a export in the index.js file.
So instead of having to require the absolute path.
People can then do `const { CommandDispatcher } = require('discord.js-commando');`