### PR TITLE
fix(typings): make CommandoMessage extends Message

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -147,7 +147,7 @@ declare module 'discord.js-commando' {
 		public setEnabledIn(guild: GuildResolvable, enabled: boolean): void;
 	}
 
-	export class CommandoMessage {
+	export class CommandoMessage extends Message {
 		public constructor(message: Message, command?: Command, argString?: string, patternMatches?: string[]);
 
 		private deleteRemainingResponses(): void;


### PR DESCRIPTION
According to
https://github.com/discordjs/Commando/blob/198d7604e3725ee88dceab9b5f296edb1b7580a5/src/extensions/message.js#L7-L12
and
https://github.com/discordjs/Commando/blob/198d7604e3725ee88dceab9b5f296edb1b7580a5/src/extensions/message.js#L53-L67
CommandoMessage class extends Message but typing doesn't.