### PR TITLE
typings(CommandoMessage): remove override

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -168,7 +168,6 @@ declare module 'discord.js-commando' {
 		public initCommand(command?: Command, argString?: string[], patternMatches?: string[]): this;
 		public parseArgs(): string | string[];
 		public static parseArgs(argString: string, argCount?: number, allowSingleQuote?: boolean): string[];
-		public reply: CommandoMessage['say'];
 		public replyEmbed: CommandoMessage['embed'];
 		public run(): Promise<null | CommandoMessage | CommandoMessage[]>;
 		public say(


### PR DESCRIPTION
this PR fixes a typescript jssue brought on by #310, the `reply` method was added when it is already defined in the base `Message` class