### PR TITLE
Update typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,20 +8,22 @@ declare module 'discord.js-commando' {
 
 		private static validateInfo(client: CommandoClient, info: ArgumentInfo);
 
-		public default: any;
+		public default: ArgumentDefault;
+		public emptyChecker: Function;
 		public error: string;
 		public infinite: boolean;
 		public key: string;
 		public label: string;
 		public max: number;
 		public min: number;
-		public oneOf: any[];
+		public oneOf: string[];
 		public parser: Function;
 		public prompt: string;
 		public type: ArgumentType;
 		public validator: Function;
 		public wait: number;
 
+		public isEmpty(val: string, msg: CommandoMessage): boolean;
 		public obtain(msg: CommandoMessage, val?: string, promptLimit?: number): Promise<ArgumentResult>;
 		public parse(val: string, msg: CommandoMessage): any | Promise<any>;
 		public validate(val: string, msg: CommandoMessage): boolean | string | Promise<boolean | string>;
@@ -37,22 +39,25 @@ declare module 'discord.js-commando' {
 		public obtain(msg: CommandoMessage, provided?: any[], promptLimit?: number): Promise<ArgumentCollectorResult>;
 	}
 
-	export class ArgumentType {
+	export abstract class ArgumentType {
 		public constructor(client: CommandoClient, id: string);
 
 		public readonly client: CommandoClient;
 		public id: string;
 
-		public parse(val: string, msg: CommandoMessage, arg: Argument): any | Promise<any>;
-		public validate(val: string, msg: CommandoMessage, arg: Argument): boolean | string | Promise<boolean | string>;
 		public isEmpty(val: string, msg: CommandoMessage, arg: Argument): boolean;
+		public abstract parse(val: string, msg: CommandoMessage, arg: Argument): any | Promise<any>;
+		public abstract validate(val: string, msg: CommandoMessage, arg: Argument): boolean | string | Promise<boolean | string>;
 	}
 
 	export class ArgumentUnionType extends ArgumentType {
 		public types: ArgumentType[];
+
+		public parse(val: string, msg: CommandoMessage, arg: Argument);
+		public validate(val: string, msg: CommandoMessage, arg: Argument): string | boolean | Promise<string | boolean>;
 	}
 
-	export class Command {
+	export abstract class Command {
 		public constructor(client: CommandoClient, info: CommandInfo);
 
 		private _globalEnabled: boolean;
@@ -63,6 +68,7 @@ declare module 'discord.js-commando' {
 		private static validateInfo(client: CommandoClient, info: CommandInfo);
 
 		public aliases: string[];
+		public argsCollector: ArgumentCollector;
 		public argsCount: number;
 		public argsSingleQuotes: boolean;
 		public argsType: string;
@@ -76,8 +82,8 @@ declare module 'discord.js-commando' {
 		public group: CommandGroup;
 		public groupID: string;
 		public guarded: boolean;
-		public hidden: boolean;
 		public guildOnly: boolean;
+		public hidden: boolean;
 		public memberName: string;
 		public name: string;
 		public nsfw: boolean;
@@ -89,7 +95,7 @@ declare module 'discord.js-commando' {
 
 		public hasPermission(message: CommandoMessage, ownerOverride?: boolean): boolean | string;
 		public isEnabledIn(guild: GuildResolvable, bypassGroup?: boolean): boolean;
-		public isUsable(message: Message): boolean;
+		public isUsable(message?: Message): boolean;
 		public onBlock(message: CommandoMessage, reason: string, data?: object): Promise<Message | Message[]>;
 		public onBlock(message: CommandoMessage, reason: 'guildOnly' | 'nsfw'): Promise<Message | Message[]>;
 		public onBlock(message: CommandoMessage, reason: 'permission', data: { response?: string }): Promise<Message | Message[]>;
@@ -98,7 +104,7 @@ declare module 'discord.js-commando' {
 		public onError(err: Error, message: CommandoMessage, args: object | string | string[], fromPattern: false, result?: ArgumentCollectorResult): Promise<Message | Message[]>;
 		public onError(err: Error, message: CommandoMessage, args: string[], fromPattern: true, result?: ArgumentCollectorResult): Promise<Message | Message[]>;
 		public reload(): void;
-		public run(message: CommandoMessage, args: object | string | string[], fromPattern: boolean, result?: ArgumentCollectorResult): Promise<Message | Message[] | null> | null;
+		public abstract run(message: CommandoMessage, args: object | string | string[], fromPattern: boolean, result?: ArgumentCollectorResult): Promise<Message | Message[] | null> | null;
 		public setEnabledIn(guild: GuildResolvable, enabled: boolean): void;
 		public unload(): void;
 		public usage(argString?: string, prefix?: string, user?: User): string;
@@ -115,9 +121,9 @@ declare module 'discord.js-commando' {
 
 		private buildCommandPattern(prefix: string): RegExp;
 		private cacheCommandoMessage(message: Message, oldMessage: Message, cmdMsg: CommandoMessage, responses: Message | Message[]): void;
-		private handleMessage(messge: Message, oldMessage?: Message): Promise<void>;
+		private handleMessage(message: Message, oldMessage?: Message): Promise<void>;
 		private inhibit(cmdMsg: CommandoMessage): Inhibition;
-		private matchDefault(message: Message, pattern: RegExp, commandNameIndex: number): CommandoMessage;
+		private matchDefault(message: Message, pattern: RegExp, commandNameIndex?: number, prefixless?: boolean): CommandoMessage;
 		private parseMessage(message: Message): CommandoMessage;
 		private shouldHandleMessage(message: Message, oldMessage?: Message): boolean;
 
@@ -134,7 +140,7 @@ declare module 'discord.js-commando' {
 	}
 
 	export class CommandGroup {
-		public constructor(client: CommandoClient, id: string, name?: string, guarded?: boolean, commands?: Command[]);
+		public constructor(client: CommandoClient, id: string, name?: string, guarded?: boolean);
 
 		public readonly client: CommandoClient;
 		public commands: Collection<string, Command>
@@ -167,7 +173,6 @@ declare module 'discord.js-commando' {
 		public embed(embed: MessageEmbed, content?: string, options?: MessageOptions | MessageAdditions);
 		public initCommand(command?: Command, argString?: string[], patternMatches?: string[]): this;
 		public parseArgs(): string | string[];
-		public static parseArgs(argString: string, argCount?: number, allowSingleQuote?: boolean): string[];
 		public replyEmbed: CommandoMessage['embed'];
 		public run(): Promise<null | CommandoMessage | CommandoMessage[]>;
 		public say(
@@ -179,6 +184,8 @@ declare module 'discord.js-commando' {
 			options?: (MessageOptions & { split: true | Exclude<MessageOptions['split'], boolean> }) | MessageAdditions
 		): Promise<CommandoMessage[]>;
 		public usage(argString?: string, prefix?: string, user?: User): string;
+
+		public static parseArgs(argString: string, argCount?: number, allowSingleQuote?: boolean): string[];
 	}
 
 	export class CommandoClient extends Client {
@@ -214,7 +221,7 @@ declare module 'discord.js-commando' {
 		public readonly settings: GuildSettingsHelper;
 
 		public commandUsage(command?: string, user?: User): string;
-		public isCommandEndabled(command: CommandResolvable): boolean;
+		public isCommandEnabled(command: CommandResolvable): boolean;
 		public isGroupEnabled(group: CommandGroupResolvable): boolean;
 		public setCommandEnabled(command: CommandResolvable, enabled: boolean): void;
 		public setGroupEnabled(group: CommandGroupResolvable, enabled: boolean): void;
@@ -226,7 +233,6 @@ declare module 'discord.js-commando' {
 		public readonly client: CommandoClient;
 		public commands: Collection<string, Command>;
 		public commandsPath: string;
-		public evalObjects: object;
 		public groups: Collection<string, CommandGroup>;
 		public types: Collection<string, ArgumentType>;
 		public unknownCommand?: Command;
@@ -236,12 +242,10 @@ declare module 'discord.js-commando' {
 		public registerCommand(command: Command | Function): CommandoRegistry;
 		public registerCommands(commands: Command[] | Function[], ignoreInvalid?: boolean): CommandoRegistry;
 		public registerCommandsIn(options: string | {}): CommandoRegistry;
-		public registerDefaultCommands(commands?: { help?: boolean, prefix?: boolean, eval?: boolean, ping?: boolean, commandState?: boolean, unknownCommand?: boolean }): CommandoRegistry;
+		public registerDefaultCommands(commands?: DefaultCommandsOptions): CommandoRegistry;
 		public registerDefaultGroups(): CommandoRegistry;
 		public registerDefaults(): CommandoRegistry;
-		public registerDefaultTypes(types?: { string?: boolean, integer?: boolean, float?: boolean, boolean?: boolean, user?: boolean, member?: boolean, role?: boolean, channel?: boolean, message?: boolean, defaultEmoji?: boolean, command?: boolean, group?: boolean }): CommandoRegistry;
-		public registerEvalObject(key: string, obj: {}): CommandoRegistry;
-		public registerEvalObjects(obj: {}): CommandoRegistry;
+		public registerDefaultTypes(types?: DefaultTypesOptions): CommandoRegistry;
 		public registerGroup(group: CommandGroup | Function | { id: string, name?: string, guarded?: boolean } | string, name?: string, guarded?: boolean): CommandoRegistry;
 		public registerGroups(groups: CommandGroup[] | Function[] | { id: string, name?: string, guarded?: boolean }[] | string[][]): CommandoRegistry;
 		public registerType(type: ArgumentType | Function): CommandoRegistry;
@@ -249,7 +253,7 @@ declare module 'discord.js-commando' {
 		public registerTypesIn(options: string | {}): CommandoRegistry;
 		public reregisterCommand(command: Command | Function, oldCommand: Command): void;
 		public resolveCommand(command: CommandResolvable): Command;
-		public resolveCommandPath(groups: string, memberName: string): string;
+		public resolveCommandPath(group: string, memberName: string): string;
 		public resolveGroup(group: CommandGroupResolvable): CommandGroup;
 		public unregisterCommand(command: Command): void;
 	}
@@ -270,14 +274,15 @@ declare module 'discord.js-commando' {
 		public set(key: string, val: any): Promise<any>;
 	}
 
-	export class SettingProvider {
-		public clear(guild: Guild | string): Promise<void>;
-		public destroy(): Promise<void>;
-		public get(guild: Guild | string, key: string, defVal?: any): any;
+	export abstract class SettingProvider {
+		public abstract clear(guild: Guild | string): Promise<void>;
+		public abstract destroy(): Promise<void>;
+		public abstract get(guild: Guild | string, key: string, defVal?: any): any;
+		public abstract init(client: CommandoClient): Promise<void>;
+		public abstract remove(guild: Guild | string, key: string): Promise<any>;
+		public abstract set(guild: Guild | string, key: string, val: any): Promise<any>;
+
 		public static getGuildID(guild: Guild | string): string;
-		public init(client: CommandoClient): Promise<void>;
-		public remove(guild: Guild | string, key: string): Promise<any>;
-		public set(guild: Guild | string, key: string, val: any): Promise<any>;
 	}
 
 	export class SQLiteProvider extends SettingProvider {
@@ -326,6 +331,7 @@ declare module 'discord.js-commando' {
 
 	export class util {
 		public static disambiguation(items: any[], label: string, property?: string): string;
+		public static escapeRegex(str: string): string;
 		public static paginate<T>(items: T[], page?: number, pageLength?: number): {
 			items: T[],
 			page: number,
@@ -344,6 +350,8 @@ declare module 'discord.js-commando' {
 		answers: Message[];
 	}
 
+	type ArgumentDefault = any | Function;
+
 	export interface ArgumentInfo {
 		key: string;
 		label?: string;
@@ -352,8 +360,8 @@ declare module 'discord.js-commando' {
 		type?: string;
 		max?: number;
 		min?: number;
-		oneOf?: any[];
-		default?: any | Function;
+		oneOf?: string[];
+		default?: ArgumentDefault;
 		infinite?: boolean;
 		validate?: Function;
 		parse?: Function;
@@ -432,7 +440,36 @@ declare module 'discord.js-commando' {
 
 	type CommandResolvable = Command | string;
 
+	interface DefaultCommandsOptions {
+		help?: boolean;
+		prefix?: boolean;
+		eval?: boolean;
+		ping?: boolean;
+		unknownCommand?: boolean;
+		commandState?: boolean;
+	}
+
+	interface DefaultTypesOptions {
+		string?: boolean;
+		integer?: boolean;
+		float?: boolean;
+		boolean?: boolean;
+		user?: boolean;
+		member?: boolean;
+		role?: boolean;
+		channel?: boolean;
+		textChannel?: boolean;
+		voiceChannel?: boolean;
+		categoryChannel?: boolean;
+		message?: boolean;
+		customEmoji?: boolean;
+		defaultEmoji?: boolean;
+		command?: boolean;
+		group?: boolean;
+	}
+
 	type Inhibitor = (msg: CommandoMessage) => false | string | Inhibition;
+
 	export interface Inhibition {
 		reason: string;
 		response?: Promise<Message>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6,7 +6,7 @@ declare module 'discord.js-commando' {
 
 		private obtainInfinite(msg: CommandoMessage, vals?: string[], promptLimit?: number): Promise<ArgumentResult>;
 
-		private static validateInfo(client: CommandoClient, info: ArgumentInfo);
+		private static validateInfo(client: CommandoClient, info: ArgumentInfo): void;
 
 		public default: ArgumentDefault;
 		public emptyChecker: Function;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -170,7 +170,8 @@ declare module 'discord.js-commando' {
 		public anyUsage(argString?: string, prefix?: string, user?: User): string;
 		public code: CommandoMessage['say'];
 		public direct: CommandoMessage['say'];
-		public embed(embed: MessageEmbed, content?: string, options?: MessageOptions | MessageAdditions);
+		public embed(embed: MessageEmbed, content?: StringResolvable, options?: (MessageOptions & { split?: false }) | MessageAdditions): Promise<CommandoMessage>;
+		public embed(embed: MessageEmbed, content?: StringResolvable, options?: (MessageOptions & { split: true | Exclude<MessageOptions['split'], boolean> }) | MessageAdditions): Promise<CommandoMessage[]>;
 		public initCommand(command?: Command, argString?: string[], patternMatches?: string[]): this;
 		public parseArgs(): string | string[];
 		public replyEmbed: CommandoMessage['embed'];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -53,7 +53,7 @@ declare module 'discord.js-commando' {
 	export class ArgumentUnionType extends ArgumentType {
 		public types: ArgumentType[];
 
-		public parse(val: string, msg: CommandoMessage, arg: Argument);
+		public parse(val: string, msg: CommandoMessage, arg: Argument): any | Promise<any>;
 		public validate(val: string, msg: CommandoMessage, arg: Argument): string | boolean | Promise<string | boolean>;
 	}
 


### PR DESCRIPTION
Extending #310:

- Adds missing public properties
- Removes typings for members that are no longer present in the source
- Defines classes that shouldn't be instantiated directly as `abstract`
- Fixes a couple of typos and reorganizes some properties to adhere to the rest of the structure

There is an inconsistency when it comes to exposing private constructors and properties, as one or two classes have those set, whilst the rest don't. Decided to leave them be for now.