### PR TITLE
Added duration argument type.

### DIFF
--- a/src/types/duration.js
+++ b/src/types/duration.js
@@ -1,0 +1,42 @@
+const ArgumentType = require('./base');
+
+class DurationArgumentType extends ArgumentType {
+	constructor(client) {
+		super(client, 'duration');
+	}
+
+	validate(val, msg, arg) {
+		if(val.includes('.')) return false;
+        // No decimals allowed!!!
+
+		const millis = timeStrToMillis(val);
+		if(millis > Number.MAX_SAFE_INTEGER || millis < 5000) {
+			arg.error = 'Time must be greater than or equal to 5 seconds.';
+			return false;
+		}
+
+		return val.split(' ').reduce((acc, timePart) => acc && !!timePart.match(/\d+(?=w|d|h|m|s)/i), true);
+	}
+
+	parse(val) {
+		return timeStrToMillis(val);
+	}
+}
+
+function timeStrToMillis(str) {
+	const weeks = +str.match(/\d+(?=w)/i);
+	const days = +str.match(/\d+(?=d)/i);
+	const hours = +str.match(/\d+(?=h)/i);
+	const minutes = +str.match(/\d+(?=m)/i);
+	const seconds = +str.match(/\d+(?=s)/i);
+
+	const millis = (weeks * 7 * 24 * 60 * 60 * 1000) +
+    (days * 24 * 60 * 60 * 1000) +
+    (hours * 60 * 60 * 1000) +
+    (minutes * 60 * 1000) +
+    (seconds * 1000);
+
+	return millis;
+}
+
+module.exports = DurationArgumentType;

--- a/test/commands/util/wait-send-message.js
+++ b/test/commands/util/wait-send-message.js
@@ -1,0 +1,32 @@
+const commando = require('../../../src');
+const { promisify } = require('util');
+
+module.exports = class WaitSendMessage extends commando.Command {
+	constructor(client) {
+		super(client, {
+			name: 'waitsendmessage',
+			aliases: ['wsm', 'wait'],
+			group: 'util',
+			memberName: 'waitsendmessage',
+			description: 'Send a message. Wait an amount of time, then edit it.',
+			examples: ['waitsendmessage 5m', 'wsm 10h'],
+			args: [
+				{
+					key: 'duration',
+					prompt: 'How long would you like the message to be edited after being sent?',
+					type: 'duration'
+				}
+			]
+		});
+	}
+
+	async run(msg, { duration }) {
+        // Send a message
+		const sentMessage = await msg.channel.send(`Waiting ${duration} ms to edit...`);
+        // Wait for the duration
+		const sleep = promisify(setTimeout);
+		await sleep(duration);
+        // Edit the message
+		return sentMessage.edit(`Successfully waited ${duration} ms!`);
+	}
+};

--- a/test/types/duration.js
+++ b/test/types/duration.js
@@ -1,0 +1,42 @@
+const commando = require('../../src');
+
+class DurationArgumentType extends commando.ArgumentType {
+	constructor(client) {
+		super(client, 'duration');
+	}
+
+	validate(val, msg, arg) {
+		if(val.includes('.')) return false;
+        // No decimals allowed!!!
+
+		const millis = timeStrToMillis(val);
+		if(millis > Number.MAX_SAFE_INTEGER || millis < 5000) {
+			arg.error = 'Time must be greater than or equal to 5 seconds.';
+			return false;
+		}
+
+		return val.split(' ').reduce((acc, timePart) => acc && !!timePart.match(/\d+(?=w|d|h|m|s)/i), true);
+	}
+
+	parse(val) {
+		return timeStrToMillis(val);
+	}
+}
+
+function timeStrToMillis(str) {
+	const weeks = +str.match(/\d+(?=w)/i);
+	const days = +str.match(/\d+(?=d)/i);
+	const hours = +str.match(/\d+(?=h)/i);
+	const minutes = +str.match(/\d+(?=m)/i);
+	const seconds = +str.match(/\d+(?=s)/i);
+
+	const millis = (weeks * 7 * 24 * 60 * 60 * 1000) +
+    (days * 24 * 60 * 60 * 1000) +
+    (hours * 60 * 60 * 1000) +
+    (minutes * 60 * 1000) +
+    (seconds * 1000);
+
+	return millis;
+}
+
+module.exports = DurationArgumentType;


### PR DESCRIPTION
An attempt at resolving issue #182 .

Takes a string like this: `1w 2d 3h 4m 5s` (this would represent 1 week, 2 days, 3 hours, 4 minutes, 5 seconds).

All fields are optional and can be supplied in any order.

`parse()` returns the amount of time in milliseconds and `validate()` ensures there is at least one time code present in the string and that the represented time is over 5 seconds (I've noticed some wonkiness with any actions that happen within 5 seconds so I've set this limit. Feel free to remove this).

I've also added the type and a command to the `test` folder to make it easier and quicker to give it a shot. The command takes a duration as an argument, sends a message, and edits the message after said duration.