### PR TITLE
Instead of testing trigger message, test latest response

### DIFF
--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -218,13 +218,13 @@ class Argument {
 				};
 			}
 
-			empty = this.isEmpty(val, msg);
-			valid = await this.validate(val, msg);
+			empty = this.isEmpty(val, responses.first());
+			valid = await this.validate(val, responses.first());
 			/* eslint-enable no-await-in-loop */
 		}
 
 		return {
-			value: await this.parse(val, msg),
+			value: await this.parse(val, answers.length ? answers[answers.length - 1] : msg),
 			cancelled: null,
 			prompts,
 			answers

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -325,10 +325,10 @@ class Argument {
 					};
 				}
 
-				valid = await this.validate(val, msg);
+				valid = await this.validate(val, responses.first());
 			}
 
-			results.push(await this.parse(val, msg));
+			results.push(await this.parse(val, answers.length ? answers[answers.length - 1] : msg));
 
 			if(vals) {
 				currentVal++;

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -218,13 +218,13 @@ class Argument {
 				};
 			}
 
-			empty = this.isEmpty(val, responses.first());
-			valid = await this.validate(val, responses.first());
+			empty = this.isEmpty(val, msg, responses.first());
+			valid = await this.validate(val, msg, responses.first());
 			/* eslint-enable no-await-in-loop */
 		}
 
 		return {
-			value: await this.parse(val, answers.length ? answers[answers.length - 1] : msg),
+			value: await this.parse(val, msg, answers.length ? answers[answers.length - 1] : msg),
 			cancelled: null,
 			prompts,
 			answers
@@ -325,10 +325,10 @@ class Argument {
 					};
 				}
 
-				valid = await this.validate(val, responses.first());
+				valid = await this.validate(val, msg, responses.first());
 			}
 
-			results.push(await this.parse(val, answers.length ? answers[answers.length - 1] : msg));
+			results.push(await this.parse(val, msg, answers.length ? answers[answers.length - 1] : msg));
 
 			if(vals) {
 				currentVal++;
@@ -348,11 +348,14 @@ class Argument {
 	/**
 	 * Checks if a value is valid for the argument
 	 * @param {string} val - Value to check
-	 * @param {CommandoMessage} msg - Message that triggered the command
+	 * @param {CommandoMessage} originalMsg - Message that triggered the command
+	 * @param {?CommandoMessage} [currentMsg=originalMsg] - Current response message
 	 * @return {boolean|string|Promise<boolean|string>}
 	 */
-	validate(val, msg) {
-		const valid = this.validator ? this.validator(val, msg, this) : this.type.validate(val, msg, this);
+	validate(val, originalMsg, currentMsg = originalMsg) {
+		const valid = this.validator ?
+			this.validator(val, originalMsg, this, currentMsg) :
+			this.type.validate(val, originalMsg, this, currentMsg);
 		if(!valid || typeof valid === 'string') return this.error || valid;
 		if(isPromise(valid)) return valid.then(vld => !vld || typeof vld === 'string' ? this.error || vld : vld);
 		return valid;
@@ -361,23 +364,25 @@ class Argument {
 	/**
 	 * Parses a value string into a proper value for the argument
 	 * @param {string} val - Value to parse
-	 * @param {CommandoMessage} msg - Message that triggered the command
+	 * @param {CommandoMessage} originalMsg - Message that triggered the command
+	 * @param {?CommandoMessage} [currentMsg=originalMsg] - Current response message
 	 * @return {*|Promise<*>}
 	 */
-	parse(val, msg) {
-		if(this.parser) return this.parser(val, msg, this);
-		return this.type.parse(val, msg, this);
+	parse(val, originalMsg, currentMsg = originalMsg) {
+		if(this.parser) return this.parser(val, originalMsg, this, currentMsg);
+		return this.type.parse(val, originalMsg, this, currentMsg);
 	}
 
 	/**
 	 * Checks whether a value for the argument is considered to be empty
 	 * @param {string} val - Value to check for emptiness
-	 * @param {CommandoMessage} msg - Message that triggered the command
+	 * @param {CommandoMessage} originalMsg - Message that triggered the command
+	 * @param {?CommandoMessage} [currentMsg=originalMsg] - Current response message
 	 * @return {boolean}
 	 */
-	isEmpty(val, msg) {
-		if(this.emptyChecker) return this.emptyChecker(val, msg, this);
-		if(this.type) return this.type.isEmpty(val, msg, this);
+	isEmpty(val, originalMsg, currentMsg = originalMsg) {
+		if(this.emptyChecker) return this.emptyChecker(val, originalMsg, this, currentMsg);
+		if(this.type) return this.type.isEmpty(val, originalMsg, this, currentMsg);
 		if(Array.isArray(val)) return val.length === 0;
 		return !val;
 	}

--- a/src/types/base.js
+++ b/src/types/base.js
@@ -28,12 +28,13 @@ class ArgumentType {
 	/**
 	 * Validates a value string against the type
 	 * @param {string} val - Value to validate
-	 * @param {CommandoMessage} msg - Message the value was obtained from
+	 * @param {CommandoMessage} originalMsg - Message that triggered the command
 	 * @param {Argument} arg - Argument the value was obtained from
+	 * @param {?CommandoMessage} [currentMsg=originalMsg] - Current response message
 	 * @return {boolean|string|Promise<boolean|string>} Whether the value is valid, or an error message
 	 * @abstract
 	 */
-	validate(val, msg, arg) { // eslint-disable-line no-unused-vars
+	validate(val, originalMsg, arg, currentMsg = originalMsg) { // eslint-disable-line no-unused-vars
 		throw new Error(`${this.constructor.name} doesn't have a validate() method.`);
 	}
 
@@ -41,12 +42,13 @@ class ArgumentType {
 	/**
 	 * Parses the raw value string into a usable value
 	 * @param {string} val - Value to parse
-	 * @param {CommandoMessage} msg - Message the value was obtained from
+	 * @param {CommandoMessage} originalMsg - Message that triggered the command
 	 * @param {Argument} arg - Argument the value was obtained from
+	 * @param {?CommandoMessage} [currentMsg=originalMsg] - Current response message
 	 * @return {*|Promise<*>} Usable value
 	 * @abstract
 	 */
-	parse(val, msg, arg) { // eslint-disable-line no-unused-vars
+	parse(val, originalMsg, arg, currentMsg = originalMsg) { // eslint-disable-line no-unused-vars
 		throw new Error(`${this.constructor.name} doesn't have a parse() method.`);
 	}
 
@@ -54,11 +56,12 @@ class ArgumentType {
 	 * Checks whether a value is considered to be empty. This determines whether the default value for an argument
 	 * should be used and changes the response to the user under certain circumstances.
 	 * @param {string} val - Value to check for emptiness
-	 * @param {CommandoMessage} msg - Message the value was obtained from
+	 * @param {CommandoMessage} originalMsg - Message that triggered the command
 	 * @param {Argument} arg - Argument the value was obtained from
+	 * @param {?CommandoMessage} [currentMsg=originalMsg] - Current response message
 	 * @return {boolean} Whether the value is empty
 	 */
-	isEmpty(val, msg, arg) { // eslint-disable-line no-unused-vars
+	isEmpty(val, originalMsg, arg, currentMsg = originalMsg) { // eslint-disable-line no-unused-vars
 		if(Array.isArray(val)) return val.length === 0;
 		return !val;
 	}


### PR DESCRIPTION
https://discord.js.org/#/docs/commando/master/class/Argument?scrollTo=validate

The `msg` parameter is listed as the message that _triggered the command_, but this breaks functionality if you need to check the message received from the prompt instead. Such as if I wanted to check if there were attachments in the message, but I don't want to check the original message, I want the new prompted message.

This seems like an oversight and should change to pass the new message rather than the original one.

This seems like the solution to a long-time bug I've had where it won't take attachment images after prompt:
[![https://cdn.discordapp.com/attachments/316734873358434304/805111520807223326/unknown.png](https://cdn.discordapp.com/attachments/316734873358434304/805111520807223326/unknown.png)](https://cdn.discordapp.com/attachments/316734873358434304/805111520807223326/unknown.png)

This has been tested and no adverse reaction have occurred when used on [Xiao](https://github.com/dragonfire535/xiao).