### PR TITLE
Allow override of Command.throttle

### DIFF
--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -361,7 +361,7 @@ class Command {
 	 * Creates/obtains the throttle object for a user, if necessary (owners are excluded)
 	 * @param {string} userID - ID of the user to throttle for
 	 * @return {?Object}
-	 * @private
+	 * @protected
 	 */
 	throttle(userID) {
 		if(!this.throttling || this.client.isOwner(userID)) return null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -63,7 +63,7 @@ declare module 'discord.js-commando' {
 		private _globalEnabled: boolean;
 		private _throttles: Map<string, object>;
 
-		private throttle(userID: string): object;
+		protected throttle(userID: string): object | null;
 
 		private static validateInfo(client: CommandoClient, info: CommandInfo);
 


### PR DESCRIPTION
- Make `Command.throttle` protected instead of private, allowing children to safely override this handling when using typescript.
- Fix the return type of `Command.throttle` to acknowledge the null response where a command is not throttling.

Given throttling is a per-command behaviour, it would be handy to be able to provide custom throttling checks as needed.
I.e. throttling for all (incl. owners), global throttling instead of per-user, etc