### PR TITLE
Emit `commandCancel` when reason is promptLimit or prompt length is zero

### DIFF
--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -193,7 +193,8 @@ module.exports = Structures.extend('Message', Message => {
 
 				collResult = await this.command.argsCollector.obtain(this, provided);
 				if(collResult.cancelled) {
-					if(collResult.prompts.length === 0 || collResult.cancelled === 'promptLimit') {
+					if (collResult.prompts.length === 0 || collResult.cancelled === 'promptLimit') {
+						this.client.emit('commandCancel', this.command, collResult.cancelled, this, collResult);
 						const err = new CommandFormatError(this);
 						return this.reply(err.message);
 					}

--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -193,7 +193,7 @@ module.exports = Structures.extend('Message', Message => {
 
 				collResult = await this.command.argsCollector.obtain(this, provided);
 				if(collResult.cancelled) {
-					if (collResult.prompts.length === 0 || collResult.cancelled === 'promptLimit') {
+					if(collResult.prompts.length === 0 || collResult.cancelled === 'promptLimit') {
 						this.client.emit('commandCancel', this.command, collResult.cancelled, this, collResult);
 						const err = new CommandFormatError(this);
 						return this.reply(err.message);


### PR DESCRIPTION
I'm not sure why this was excluded originally, but I noticed it earlier today when someone inadvertently used a command incorrectly and triggered this. The event was never emitted even though the command was in-fact canceled.