### PR TITLE
Improve typings in CommandoMessage class

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -161,6 +161,7 @@ declare module 'discord.js-commando' {
 		public responsePositions: { [key: string]: number } | null;
 		public responses: { [key: string]: CommandoMessage[] } | null;
 		public readonly guild: CommandoGuild;
+		public readonly client: CommandoClient;
 
 		private deleteRemainingResponses(): void;
 		private editCurrentResponse(id: string, options: MessageEditOptions | Exclude<MessageAdditions, MessageAttachment>): Promise<CommandoMessage | CommandoMessage[]>;


### PR DESCRIPTION
Override `client` member of CommandoMessage class as CommandoClient type

Closes #381 