### PR TITLE
Fix permission check for default commands

### DIFF
--- a/src/commands/commands/disable.js
+++ b/src/commands/commands/disable.js
@@ -29,7 +29,7 @@ module.exports = class DisableCommandCommand extends Command {
 
 	hasPermission(msg) {
 		if(!msg.guild) return this.client.isOwner(msg.author);
-		return msg.member.hasPermission('ADMINISTRATOR') || this.client.isOwner(msg.author);
+		return msg.member.permissions.has('ADMINISTRATOR') || this.client.isOwner(msg.author);
 	}
 
 	run(msg, args) {

--- a/src/commands/commands/enable.js
+++ b/src/commands/commands/enable.js
@@ -29,7 +29,7 @@ module.exports = class EnableCommandCommand extends Command {
 
 	hasPermission(msg) {
 		if(!msg.guild) return this.client.isOwner(msg.author);
-		return msg.member.hasPermission('ADMINISTRATOR') || this.client.isOwner(msg.author);
+		return msg.member.permissions.has('ADMINISTRATOR') || this.client.isOwner(msg.author);
 	}
 
 	run(msg, args) {

--- a/src/commands/commands/groups.js
+++ b/src/commands/commands/groups.js
@@ -16,7 +16,7 @@ module.exports = class ListGroupsCommand extends Command {
 
 	hasPermission(msg) {
 		if(!msg.guild) return this.client.isOwner(msg.author);
-		return msg.member.hasPermission('ADMINISTRATOR') || this.client.isOwner(msg.author);
+		return msg.member.permissions.has('ADMINISTRATOR') || this.client.isOwner(msg.author);
 	}
 
 	run(msg) {

--- a/src/commands/util/prefix.js
+++ b/src/commands/util/prefix.js
@@ -41,7 +41,7 @@ module.exports = class PrefixCommand extends Command {
 
 		// Check the user's permission before changing anything
 		if(msg.guild) {
-			if(!msg.member.hasPermission('ADMINISTRATOR') && !this.client.isOwner(msg.author)) {
+			if(!msg.member.permissions.has('ADMINISTRATOR') && !this.client.isOwner(msg.author)) {
 				return msg.reply('Only administrators may change the command prefix.');
 			}
 		} else if(!this.client.isOwner(msg.author)) {


### PR DESCRIPTION
GuildMember#hasPermission was removed from discord.js in PR #5152 but the default commands still reference it which causes this error: `TypeError: msg.member.hasPermission is not a function`

Resolves #370 