### PR TITLE
fix(Command): respect bypassGroup for cmds ran in DMs

### DIFF
--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -407,7 +407,7 @@ class Command {
 	 */
 	isEnabledIn(guild, bypassGroup) {
 		if(this.guarded) return true;
-		if(!guild) return this.group._globalEnabled && this._globalEnabled;
+		if(!guild) return (bypassGroup || this.group._globalEnabled) && this._globalEnabled;
 		guild = this.client.guilds.resolve(guild);
 		return (bypassGroup || guild.isGroupEnabled(this.group)) && guild.isCommandEnabled(this);
 	}


### PR DESCRIPTION
Command#isEnabledIn doesn't take the bypassGroup argument into account if the method is called with guild=null (DMs). 
This PR fixes that.

I found this bug by doing:
- in DMs with the client try to enable an already enabled command which is in a disabled group.
- it says the "enabled command but group is disabled" message.

What should happen:
- it should say the "command is already enabled but group is not" message, like when you use enable on a command with equal state in guilds.