### PR TITLE
chore(memberType): Use GuildMemberManager#resolve instead of Guild#member

### DIFF
--- a/src/types/member.js
+++ b/src/types/member.js
@@ -41,7 +41,7 @@ class MemberArgumentType extends ArgumentType {
 
 	parse(val, msg) {
 		const matches = val.match(/^(?:<@!?)?([0-9]+)>?$/);
-		if(matches) return msg.guild.member(matches[1]) || null;
+		if(matches) return msg.guild.members.resolve(matches[1]) || null;
 		const search = val.toLowerCase();
 		const members = msg.guild.members.cache.filter(memberFilterInexact(search));
 		if(members.size === 0) return null;


### PR DESCRIPTION
[Guild#member](https://discord.js.org/#/docs/main/stable/class/Guild?scrollTo=member) is getting removed in v13 so replace it with [GuildMemberManager#resolve](https://discord.js.org/#/docs/main/master/class/GuildMemberManager?scrollTo=resolve).