### PR TITLE
fix: replace resolveString with verifyString

### DIFF
--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -283,7 +283,7 @@ module.exports = Structures.extend('Message', Message => {
 				}
 			}
 
-			content = verifyString(this.options.content);
+			content = verifyString(content);
 
 			switch(type) {
 				case 'plain':

--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -283,7 +283,7 @@ module.exports = Structures.extend('Message', Message => {
 				}
 			}
 
-			content = verifyString(this.options.content, RangeError, 'MESSAGE_CONTENT_TYPE', false)
+			content = verifyString(this.options.content, RangeError, 'MESSAGE_CONTENT_TYPE', false);
 
 			switch(type) {
 				case 'plain':

--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -1,4 +1,4 @@
-const { Structures, escapeMarkdown, splitMessage, resolveString } = require('discord.js');
+const { Structures, escapeMarkdown, splitMessage, verifyString } = require('discord.js');
 const { oneLine } = require('common-tags');
 const Command = require('../commands/base');
 const FriendlyError = require('../errors/friendly');
@@ -283,7 +283,7 @@ module.exports = Structures.extend('Message', Message => {
 				}
 			}
 
-			content = resolveString(content);
+			content = verifyString(this.options.content, RangeError, 'MESSAGE_CONTENT_TYPE', false)
 
 			switch(type) {
 				case 'plain':

--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -1,4 +1,4 @@
-const { Structures, escapeMarkdown, splitMessage, verifyString } = require('discord.js');
+const { Structures, Util: { escapeMarkdown, splitMessage, verifyString } } = require('discord.js');
 const { oneLine } = require('common-tags');
 const Command = require('../commands/base');
 const FriendlyError = require('../errors/friendly');

--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -363,7 +363,7 @@ module.exports = Structures.extend('Message', Message => {
 
 		/**
 		 * Responds with a plain message
-		 * @param {StringResolvable} content - Content for the message
+		 * @param {string} content - Content for the message
 		 * @param {MessageOptions} [options] - Options for the message
 		 * @return {Promise<Message|Message[]>}
 		 */
@@ -377,7 +377,7 @@ module.exports = Structures.extend('Message', Message => {
 
 		/**
 		 * Responds with a reply message
-		 * @param {StringResolvable} content - Content for the message
+		 * @param {string} content - Content for the message
 		 * @param {MessageOptions} [options] - Options for the message
 		 * @return {Promise<Message|Message[]>}
 		 */
@@ -391,7 +391,7 @@ module.exports = Structures.extend('Message', Message => {
 
 		/**
 		 * Responds with a direct message
-		 * @param {StringResolvable} content - Content for the message
+		 * @param {string} content - Content for the message
 		 * @param {MessageOptions} [options] - Options for the message
 		 * @return {Promise<Message|Message[]>}
 		 */
@@ -406,7 +406,7 @@ module.exports = Structures.extend('Message', Message => {
 		/**
 		 * Responds with a code message
 		 * @param {string} lang - Language for the code block
-		 * @param {StringResolvable} content - Content for the message
+		 * @param {string} content - Content for the message
 		 * @param {MessageOptions} [options] - Options for the message
 		 * @return {Promise<Message|Message[]>}
 		 */
@@ -423,7 +423,7 @@ module.exports = Structures.extend('Message', Message => {
 		/**
 		 * Responds with an embed
 		 * @param {RichEmbed|Object} embed - Embed to send
-		 * @param {StringResolvable} [content] - Content for the message
+		 * @param {string} [content] - Content for the message
 		 * @param {MessageOptions} [options] - Options for the message
 		 * @return {Promise<Message|Message[]>}
 		 */
@@ -436,7 +436,7 @@ module.exports = Structures.extend('Message', Message => {
 		/**
 		 * Responds with a mention + embed
 		 * @param {RichEmbed|Object} embed - Embed to send
-		 * @param {StringResolvable} [content] - Content for the message
+		 * @param {string} [content] - Content for the message
 		 * @param {MessageOptions} [options] - Options for the message
 		 * @return {Promise<Message|Message[]>}
 		 */

--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -283,7 +283,7 @@ module.exports = Structures.extend('Message', Message => {
 				}
 			}
 
-			content = verifyString(this.options.content, RangeError, 'MESSAGE_CONTENT_TYPE', false);
+			content = verifyString(this.options.content);
 
 			switch(type) {
 				case 'plain':

--- a/src/index.js
+++ b/src/index.js
@@ -86,10 +86,6 @@ module.exports = {
  * @see {@link https://discord.js.org/#/docs/main/master/class/Role}
  */
 /**
- * @external StringResolvable
- * @see {@link https://discord.js.org/#/docs/main/master/typedef/StringResolvable}
- */
-/**
  * @external TextChannel
  * @see {@link https://discord.js.org/#/docs/main/master/class/TextChannel}
  */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'discord.js-commando' {
-	import { Client, ClientEvents, ClientOptions, Collection, Guild, GuildResolvable, Message, MessageAttachment, MessageEditOptions, MessageEmbed, MessageOptions, MessageAdditions, MessageReaction, PermissionResolvable, PermissionString, StringResolvable, User, UserResolvable } from 'discord.js';
+	import { Client, ClientEvents, ClientOptions, Collection, Guild, GuildResolvable, Message, MessageAttachment, MessageEditOptions, MessageEmbed, MessageOptions, MessageAdditions, MessageReaction, PermissionResolvable, PermissionString, User, UserResolvable } from 'discord.js';
 
 	export class Argument {
 		private constructor(client: CommandoClient, info: ArgumentInfo);
@@ -172,18 +172,18 @@ declare module 'discord.js-commando' {
 		public anyUsage(argString?: string, prefix?: string, user?: User): string;
 		public code: CommandoMessage['say'];
 		public direct: CommandoMessage['say'];
-		public embed(embed: MessageEmbed, content?: StringResolvable, options?: (MessageOptions & { split?: false }) | MessageAdditions): Promise<CommandoMessage>;
-		public embed(embed: MessageEmbed, content?: StringResolvable, options?: (MessageOptions & { split: true | Exclude<MessageOptions['split'], boolean> }) | MessageAdditions): Promise<CommandoMessage[]>;
+		public embed(embed: MessageEmbed, content?: string, options?: (MessageOptions & { split?: false }) | MessageAdditions): Promise<CommandoMessage>;
+		public embed(embed: MessageEmbed, content?: string, options?: (MessageOptions & { split: true | Exclude<MessageOptions['split'], boolean> }) | MessageAdditions): Promise<CommandoMessage[]>;
 		public initCommand(command?: Command, argString?: string[], patternMatches?: string[]): this;
 		public parseArgs(): string | string[];
 		public replyEmbed: CommandoMessage['embed'];
 		public run(): Promise<null | CommandoMessage | CommandoMessage[]>;
 		public say(
-			content: StringResolvable | (MessageOptions & { split?: false }) | MessageAdditions,
+			content: string | (MessageOptions & { split?: false }) | MessageAdditions,
 			options?: (MessageOptions & { split?: false }) | MessageAdditions
 		): Promise<CommandoMessage>;
 		public say(
-			content: StringResolvable | (MessageOptions & { split: true | Exclude<MessageOptions['split'], boolean> }) | MessageAdditions,
+			content: string | (MessageOptions & { split: true | Exclude<MessageOptions['split'], boolean> }) | MessageAdditions,
 			options?: (MessageOptions & { split: true | Exclude<MessageOptions['split'], boolean> }) | MessageAdditions
 		): Promise<CommandoMessage[]>;
 		public usage(argString?: string, prefix?: string, user?: User): string;
@@ -486,7 +486,7 @@ declare module 'discord.js-commando' {
 	type ResponseType = 'reply' | 'plain' | 'direct' | 'code';
 
 	interface RespondOptions {
-		content: StringResolvable | MessageOptions;
+		content: string | MessageOptions;
 		fromEdit?: boolean;
 		options?: MessageOptions;
 		lang?: string;
@@ -494,7 +494,7 @@ declare module 'discord.js-commando' {
 	}
 
 	interface RespondEditOptions {
-		content: StringResolvable | MessageEditOptions | Exclude<MessageAdditions, MessageAttachment>;
+		content: string | MessageEditOptions | Exclude<MessageAdditions, MessageAttachment>;
 		options?: MessageEditOptions | Exclude<MessageAdditions, MessageAttachment>;
 		type?: ResponseType;
 	}


### PR DESCRIPTION
Replaces a reference to the now removed `Util.resolveString` with `Util.verifyString`
Introduced by https://github.com/discordjs/discord.js/pull/4880