### PR TITLE
Enhancement registerCommandsIn (#407)

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -195,7 +195,7 @@ class CommandoRegistry {
 		}
 		for(const group of Object.values(obj)) {
 			for(let [name, command] of Object.entries(group)) {
-				if(options.subDirs && options.subDirs.includes(name)) {
+				if(options.subdirs && options.subdirs.includes(name)) {
 					for(let subCommand of Object.values(command)) {
 						push(subCommand);
 					}

--- a/src/registry.js
+++ b/src/registry.js
@@ -189,10 +189,19 @@ class CommandoRegistry {
 	registerCommandsIn(options) {
 		const obj = require('require-all')(options);
 		const commands = [];
+		function push(command) {
+			if(typeof command.default === 'function') command = command.default;
+			commands.push(command);
+		}
 		for(const group of Object.values(obj)) {
-			for(let command of Object.values(group)) {
-				if(typeof command.default === 'function') command = command.default;
-				commands.push(command);
+			for(let [name, command] of Object.entries(group)) {
+				if(options.subDirs && options.subDirs.includes(name)) {
+					for(let subCommand of Object.values(command)) {
+						push(subCommand);
+					}
+				} else {
+					push(command);
+				}
 			}
 		}
 		if(typeof options === 'string' && !this.commandsPath) this.commandsPath = options;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -244,7 +244,7 @@ declare module 'discord.js-commando' {
 		public findGroups(searchString?: string, exact?: boolean): CommandGroup[];
 		public registerCommand(command: Command | Function): CommandoRegistry;
 		public registerCommands(commands: Command[] | Function[], ignoreInvalid?: boolean): CommandoRegistry;
-		public registerCommandsIn(options: string | { dirname: string, subDirs: []}): CommandoRegistry;
+		public registerCommandsIn(options: string | { dirname: string, subdirs: []}): CommandoRegistry;
 		public registerDefaultCommands(commands?: DefaultCommandsOptions): CommandoRegistry;
 		public registerDefaultGroups(): CommandoRegistry;
 		public registerDefaults(): CommandoRegistry;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -244,7 +244,7 @@ declare module 'discord.js-commando' {
 		public findGroups(searchString?: string, exact?: boolean): CommandGroup[];
 		public registerCommand(command: Command | Function): CommandoRegistry;
 		public registerCommands(commands: Command[] | Function[], ignoreInvalid?: boolean): CommandoRegistry;
-		public registerCommandsIn(options: string | {}): CommandoRegistry;
+		public registerCommandsIn(options: string | { dirname: string, subDirs: []}): CommandoRegistry;
 		public registerDefaultCommands(commands?: DefaultCommandsOptions): CommandoRegistry;
 		public registerDefaultGroups(): CommandoRegistry;
 		public registerDefaults(): CommandoRegistry;


### PR DESCRIPTION
```javascript
.registerCommandsIn({ dirname: path.join(__dirname, 'commands'), subdirs: ['warnSystem', 'punishments'] });
```
Added ability to add subdirectories, for an easier life if there are a lot of files present. 

```
├── commands/
│   └── moderation/
│           └── warnSystem/
│                    └── warn.js
│           └── punishments/
│                   └── punishments.js
│           └── ban.js
│
└── index.js
```
If the name of the file matches one of the subdirectories it will iterate over it once more.

See #407 