### PR TITLE
Fixed critical token leak in eval command

### DIFF
--- a/src/commands/util/eval.js
+++ b/src/commands/util/eval.js
@@ -78,7 +78,8 @@ module.exports = class EvalCommand extends Command {
 	makeResultMessages(result, hrDiff, input = null) {
 		const inspected = util.inspect(result, { depth: 0 })
 			.replace(nlPattern, '\n')
-			.replace(this.sensitivePattern, '--snip--');
+			.replace(this.sensitivePattern, '--snip--')
+			.replace(escapeRegex(`/${this.client.token}/gi`), "'--snip--'");
 		const split = inspected.split('\n');
 		const last = inspected.length - 1;
 		const prependPart = inspected[0] !== '{' && inspected[0] !== '[' && inspected[0] !== "'" ? split[0] : inspected[0];


### PR DESCRIPTION
Before you could eval 'this.sensitivePattern' or 'this._sensitivePattern' to gain the token and now you can't since the escaped preifx will also get replaced in the result message.