### PR TITLE
Fix : The "Installation" field.

### DIFF
--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -30,5 +30,5 @@ Additionally, it makes full use of ES2017's `async`/`await` functionality for cl
 - Command throttling/cooldowns
 
 ## Installation
-**Node 8.6.0 or newer is required.**  
+**Node 12.0.0 or newer is required.**  
 `npm install discord.js-commando`


### PR DESCRIPTION
Fix the required node version in the "Installation" field.
The current Commando should require node v12.0.0 or higher, but it was v8.0.0, so we added a fix.