### PR TITLE
Rewrite Commando for discord.js master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 npm-debug.log
 yarn.lock
 yarn-error.log
+pnpm-lock.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 yarn.lock
 yarn-error.log
 pnpm-lock.yaml
+test/auth.js

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	"types": "./typings/index.d.ts",
 	"dependencies": {
 		"common-tags": "^1.8.0",
+		"discord.js": "^13.0.0-dev.63ce065.1626653031",
 		"emoji-regex": "^9.2.0",
 		"is-promise": "^4.0.0",
 		"require-all": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
 	"main": "src/index",
 	"types": "./typings/index.d.ts",
 	"dependencies": {
+		"@discordjs/collection": "0.1.6",
 		"common-tags": "^1.8.0",
-		"discord.js": "^13.0.0-dev.63ce065.1626653031",
 		"emoji-regex": "^9.2.0",
 		"is-promise": "^4.0.0",
 		"require-all": "^3.0.0"

--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,4 @@
-const discord = require('discord.js');
+const discord = require('./extensions/extender')(require('discord.js'));
 const CommandoRegistry = require('./registry');
 const CommandDispatcher = require('./dispatcher');
 const GuildSettingsHelper = require('./providers/helper');
@@ -61,7 +61,9 @@ class CommandoClient extends discord.Client {
 
 		// Set up command handling
 		const msgErr = err => { this.emit('error', err); };
-		this.on('message', message => { this.dispatcher.handleMessage(message).catch(msgErr); });
+		this.on('messageCreate', message => { 
+			this.dispatcher.handleMessage(message).catch(msgErr); 
+		});
 		this.on('messageUpdate', (oldMessage, newMessage) => {
 			this.dispatcher.handleMessage(newMessage, oldMessage).catch(msgErr);
 		});

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -1,4 +1,4 @@
-const { escapeMarkdown } = require('discord.js').Util;
+const { escapeMarkdown } = require('../extensions/extender').Util;
 const { oneLine, stripIndents } = require('common-tags');
 const isPromise = require('is-promise');
 const ArgumentUnionType = require('../types/union');

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -1,4 +1,4 @@
-const { escapeMarkdown } = require('../extensions/extender').Util;
+const { escapeMarkdown } = require('discord.js').Util;
 const { oneLine, stripIndents } = require('common-tags');
 const isPromise = require('is-promise');
 const ArgumentUnionType = require('../types/union');
@@ -190,11 +190,11 @@ class Argument {
 			`));
 
 			// Get the user's response
-			const responses = await msg.channel.awaitMessages(msg2 => msg2.author.id === msg.author.id, {
+			const responses = await msg.channel.awaitMessages({
+				filter: msg2 => msg2.author.id === msg.author.id,
 				max: 1,
 				time: wait
 			});
-
 			// Make sure they actually answered
 			if(responses && responses.size === 1) {
 				answers.push(responses.first());
@@ -288,7 +288,8 @@ class Argument {
 				}
 
 				// Get the user's response
-				const responses = await msg.channel.awaitMessages(msg2 => msg2.author.id === msg.author.id, {
+				const responses = await msg.channel.awaitMessages({
+					filter: msg2 => msg2.author.id === msg.author.id,
 					max: 1,
 					time: wait
 				});

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -1,4 +1,4 @@
-const { escapeMarkdown } = require('discord.js');
+const { escapeMarkdown } = require('discord.js').Util;
 const { oneLine, stripIndents } = require('common-tags');
 const isPromise = require('is-promise');
 const ArgumentUnionType = require('../types/union');

--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { escapeMarkdown } = require('discord.js');
+const { escapeMarkdown } = require('discord.js').Util;
 const { oneLine, stripIndents } = require('common-tags');
 const ArgumentCollector = require('./collector');
 const { permissions } = require('../util');
@@ -371,7 +371,7 @@ class Command {
 			throttle = {
 				start: Date.now(),
 				usages: 0,
-				timeout: this.client.setTimeout(() => {
+				timeout: setTimeout(() => {
 					this._throttles.delete(userID);
 				}, this.throttling.duration * 1000)
 			};

--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -371,7 +371,7 @@ class Command {
 			throttle = {
 				start: Date.now(),
 				usages: 0,
-				timeout: setTimeout(() => {
+				timeout: this.client.setTimeout(() => {
 					this._throttles.delete(userID);
 				}, this.throttling.duration * 1000)
 			};

--- a/src/commands/group.js
+++ b/src/commands/group.js
@@ -1,4 +1,6 @@
-const discord = require('discord.js');
+const Collection = require('@discordjs/collection');
+
+
 
 /** A group for commands. Whodathunkit? */
 class CommandGroup {
@@ -37,7 +39,7 @@ class CommandGroup {
 		 * The commands in this group (added upon their registration)
 		 * @type {Collection<string, Command>}
 		 */
-		this.commands = new discord.Collection();
+		this.commands = new Collection();
 
 		/**
 		 * Whether or not this group is protected from being disabled

--- a/src/commands/util/eval.js
+++ b/src/commands/util/eval.js
@@ -1,5 +1,5 @@
 const util = require('util');
-const discord = require('discord.js');
+const { Util } = require('discord.js');
 const tags = require('common-tags');
 const { escapeRegex } = require('../../util');
 const Command = require('../base');
@@ -88,14 +88,14 @@ module.exports = class EvalCommand extends Command {
 		const prepend = `\`\`\`javascript\n${prependPart}\n`;
 		const append = `\n${appendPart}\n\`\`\``;
 		if(input) {
-			return discord.splitMessage(tags.stripIndents`
+			return Util.splitMessage(tags.stripIndents`
 				*Executed in ${hrDiff[0] > 0 ? `${hrDiff[0]}s ` : ''}${hrDiff[1] / 1000000}ms.*
 				\`\`\`javascript
 				${inspected}
 				\`\`\`
 			`, { maxLength: 1900, prepend, append });
 		} else {
-			return discord.splitMessage(tags.stripIndents`
+			return Util.splitMessage(tags.stripIndents`
 				*Callback executed after ${hrDiff[0] > 0 ? `${hrDiff[0]}s ` : ''}${hrDiff[1] / 1000000}ms.*
 				\`\`\`javascript
 				${inspected}

--- a/src/extensions/extender.js
+++ b/src/extensions/extender.js
@@ -1,0 +1,10 @@
+const CommandoMessage = require('./message')
+const CommandoGuild = require('./guild')
+
+module.exports = Discord => {
+    
+	CommandoMessage(Discord)
+    CommandoGuild(Discord)
+
+	return Discord;
+};

--- a/src/extensions/guild.js
+++ b/src/extensions/guild.js
@@ -1,148 +1,156 @@
-const { Structures } = require('discord.js');
 const Command = require('../commands/base');
 const GuildSettingsHelper = require('../providers/helper');
 
-module.exports = Structures.extend('Guild', Guild => {
 	/**
 	 * A fancier Guild for fancier people.
 	 * @extends Guild
 	 */
-	class CommandoGuild extends Guild {
-		constructor(...args) {
-			super(...args);
+
+module.exports = Discord => {
+
+	/**
+	 * Sets whether a command is enabled in the guild
+	 * @param {CommandResolvable} command - Command to set status of
+	 * @param {boolean} enabled - Whether the command should be enabled
+	 */
+
+	Discord.Guild.prototype.setCommandEnabled = function (command, enabled) {
+		command = this.client.registry.resolveCommand(command);
+		if (command.guarded) throw new Error('The command is guarded.');
+		if (typeof enabled === 'undefined') throw new TypeError('Enabled must not be undefined.');
+		enabled = Boolean(enabled);
+		if (!this._commandsEnabled) {
+			/**
+			 * Map object of internal command statuses, mapped by command name
+			 * @type {Object}
+			 * @private
+			 */
+			this._commandsEnabled = {};
+		}
+		this._commandsEnabled[command.name] = enabled;
+		/**
+		 * Emitted whenever a command is enabled/disabled in a guild
+		 * @event CommandoClient#commandStatusChange
+		 * @param {?CommandoGuild} guild - Guild that the command was enabled/disabled in (null for global)
+		 * @param {Command} command - Command that was enabled/disabled
+		 * @param {boolean} enabled - Whether the command is enabled
+		 */
+		this.client.emit('commandStatusChange', this, command, enabled);
+	}
+
+	/**
+ * Checks whether a command is enabled in the guild (does not take the command's group status into account)
+ * @param {CommandResolvable} command - Command to check status of
+ * @return {boolean}
+ */
+	Discord.Guild.prototype.isCommandEnabled = function (command) {
+		command = this.client.registry.resolveCommand(command);
+		if (command.guarded) return true;
+		if (!this._commandsEnabled || typeof this._commandsEnabled[command.name] === 'undefined') {
+			return command._globalEnabled;
+		}
+		return this._commandsEnabled[command.name];
+	}
+
+
+	/**
+	 * Sets whether a command group is enabled in the guild
+	 * @param {CommandGroupResolvable} group - Group to set status of
+	 * @param {boolean} enabled - Whether the group should be enabled
+	 */
+	Discord.Guild.prototype.setGroupEnabled = function (group, enabled) {
+		group = this.client.registry.resolveGroup(group);
+		if (group.guarded) throw new Error('The group is guarded.');
+		if (typeof enabled === 'undefined') throw new TypeError('Enabled must not be undefined.');
+		enabled = Boolean(enabled);
+		if (!this._groupsEnabled) {
+			/**
+			 * Internal map object of group statuses, mapped by group ID
+			 * @type {Object}
+			 * @private
+			 */
+			this._groupsEnabled = {};
+		}
+		this._groupsEnabled[group.id] = enabled;
+		/**
+ * Emitted whenever a command group is enabled/disabled in a guild
+ * @event CommandoClient#groupStatusChange
+ * @param {?CommandoGuild} guild - Guild that the group was enabled/disabled in (null for global)
+ * @param {CommandGroup} group - Group that was enabled/disabled
+ * @param {boolean} enabled - Whether the group is enabled
+ */
+		this.client.emit('groupStatusChange', this, group, enabled);
+	}
+
+
+	/**
+	 * Checks whether a command group is enabled in the guild
+	 * @param {CommandGroupResolvable} group - Group to check status of
+	 * @return {boolean}
+	 */
+	Discord.Guild.prototype.isGroupEnabled = function (group) {
+		group = this.client.registry.resolveGroup(group);
+		if (group.guarded) return true;
+		if (!this._groupsEnabled || typeof this._groupsEnabled[group.id] === 'undefined') return group._globalEnabled;
+		return this._groupsEnabled[group.id];
+	}
+
+
+	/**
+	 * Creates a command usage string using the guild's prefix
+	 * @param {string} [command] - A command + arg string
+	 * @param {User} [user=this.client.user] - User to use for the mention command format
+	 * @return {string}
+	 */
+	Discord.Guild.prototype.commandUsage = function (command, user = this.client.user) {
+		return Command.usage(command, this.commandPrefix, user);
+	}
+
+	/**
+	 * Command prefix in the guild. An empty string indicates that there is no prefix, and only mentions will be used.
+	 * Setting to `null` means that the prefix from {@link CommandoClient#commandPrefix} will be used instead.
+	 * @type {string}
+	 * @emits {@link CommandoClient#commandPrefixChange}
+	 */
+
+	Object.defineProperty(Discord.Guild.prototype, "commandPrefix", {
+
+
+		get: function commandPrefix() {
+			if (!this._commandPrefix || this._commandPrefix === null) {
+				this._commandPrefix = null;
+				return this.client.commandPrefix;
+			}
+			return this._commandPrefix;
+		},
+
+		set: function commandPrefix(prefix) {
+			this._commandPrefix = prefix;
+
+			/**
+		 * Emitted whenever a guild's command prefix is changed
+		 * @event CommandoClient#commandPrefixChange
+		 * @param {?CommandoGuild} guild - Guild that the prefix was changed in (null for global)
+		 * @param {?string} prefix - New command prefix (null for default)
+		 */
+			this.client.emit('commandPrefixChange', this, this._commandPrefix);
+		}
+	});
 
 			/**
 			 * Shortcut to use setting provider methods for this guild
 			 * @type {GuildSettingsHelper}
 			 */
-			this.settings = new GuildSettingsHelper(this.client, this);
 
-			/**
-			 * Internal command prefix for the guild, controlled by the {@link CommandoGuild#commandPrefix}
-			 * getter/setter
-			 * @name CommandoGuild#_commandPrefix
-			 * @type {?string}
-			 * @private
-			 */
-			this._commandPrefix = null;
-		}
-
-		/**
-		 * Command prefix in the guild. An empty string indicates that there is no prefix, and only mentions will be used.
-		 * Setting to `null` means that the prefix from {@link CommandoClient#commandPrefix} will be used instead.
-		 * @type {string}
-		 * @emits {@link CommandoClient#commandPrefixChange}
-		 */
-		get commandPrefix() {
-			if(this._commandPrefix === null) return this.client.commandPrefix;
-			return this._commandPrefix;
-		}
-
-		set commandPrefix(prefix) {
-			this._commandPrefix = prefix;
-			/**
-			 * Emitted whenever a guild's command prefix is changed
-			 * @event CommandoClient#commandPrefixChange
-			 * @param {?CommandoGuild} guild - Guild that the prefix was changed in (null for global)
-			 * @param {?string} prefix - New command prefix (null for default)
-			 */
-			this.client.emit('commandPrefixChange', this, this._commandPrefix);
-		}
-
-		/**
-		 * Sets whether a command is enabled in the guild
-		 * @param {CommandResolvable} command - Command to set status of
-		 * @param {boolean} enabled - Whether the command should be enabled
-		 */
-		setCommandEnabled(command, enabled) {
-			command = this.client.registry.resolveCommand(command);
-			if(command.guarded) throw new Error('The command is guarded.');
-			if(typeof enabled === 'undefined') throw new TypeError('Enabled must not be undefined.');
-			enabled = Boolean(enabled);
-			if(!this._commandsEnabled) {
-				/**
-				 * Map object of internal command statuses, mapped by command name
-				 * @type {Object}
-				 * @private
-				 */
-				this._commandsEnabled = {};
+	Object.defineProperty(Discord.Guild.prototype, "settings", {
+		get: function () {
+			if (!this._settings || this._settings == null) {
+				this._settings = new GuildSettingsHelper(this.client, this);
 			}
-			this._commandsEnabled[command.name] = enabled;
-			/**
-			 * Emitted whenever a command is enabled/disabled in a guild
-			 * @event CommandoClient#commandStatusChange
-			 * @param {?CommandoGuild} guild - Guild that the command was enabled/disabled in (null for global)
-			 * @param {Command} command - Command that was enabled/disabled
-			 * @param {boolean} enabled - Whether the command is enabled
-			 */
-			this.client.emit('commandStatusChange', this, command, enabled);
+			return this._settings
 		}
+	});
 
-		/**
-		 * Checks whether a command is enabled in the guild (does not take the command's group status into account)
-		 * @param {CommandResolvable} command - Command to check status of
-		 * @return {boolean}
-		 */
-		isCommandEnabled(command) {
-			command = this.client.registry.resolveCommand(command);
-			if(command.guarded) return true;
-			if(!this._commandsEnabled || typeof this._commandsEnabled[command.name] === 'undefined') {
-				return command._globalEnabled;
-			}
-			return this._commandsEnabled[command.name];
-		}
 
-		/**
-		 * Sets whether a command group is enabled in the guild
-		 * @param {CommandGroupResolvable} group - Group to set status of
-		 * @param {boolean} enabled - Whether the group should be enabled
-		 */
-		setGroupEnabled(group, enabled) {
-			group = this.client.registry.resolveGroup(group);
-			if(group.guarded) throw new Error('The group is guarded.');
-			if(typeof enabled === 'undefined') throw new TypeError('Enabled must not be undefined.');
-			enabled = Boolean(enabled);
-			if(!this._groupsEnabled) {
-				/**
-				 * Internal map object of group statuses, mapped by group ID
-				 * @type {Object}
-				 * @private
-				 */
-				this._groupsEnabled = {};
-			}
-			this._groupsEnabled[group.id] = enabled;
-			/**
-			 * Emitted whenever a command group is enabled/disabled in a guild
-			 * @event CommandoClient#groupStatusChange
-			 * @param {?CommandoGuild} guild - Guild that the group was enabled/disabled in (null for global)
-			 * @param {CommandGroup} group - Group that was enabled/disabled
-			 * @param {boolean} enabled - Whether the group is enabled
-			 */
-			this.client.emit('groupStatusChange', this, group, enabled);
-		}
 
-		/**
-		 * Checks whether a command group is enabled in the guild
-		 * @param {CommandGroupResolvable} group - Group to check status of
-		 * @return {boolean}
-		 */
-		isGroupEnabled(group) {
-			group = this.client.registry.resolveGroup(group);
-			if(group.guarded) return true;
-			if(!this._groupsEnabled || typeof this._groupsEnabled[group.id] === 'undefined') return group._globalEnabled;
-			return this._groupsEnabled[group.id];
-		}
-
-		/**
-		 * Creates a command usage string using the guild's prefix
-		 * @param {string} [command] - A command + arg string
-		 * @param {User} [user=this.client.user] - User to use for the mention command format
-		 * @return {string}
-		 */
-		commandUsage(command, user = this.client.user) {
-			return Command.usage(command, this.commandPrefix, user);
-		}
-	}
-
-	return CommandoGuild;
-});
+}

--- a/src/extensions/message.js
+++ b/src/extensions/message.js
@@ -1,535 +1,532 @@
-const { Structures, escapeMarkdown, splitMessage, resolveString } = require('discord.js');
-const { oneLine } = require('common-tags');
 const Command = require('../commands/base');
+
+const { oneLine } = require('common-tags');
 const FriendlyError = require('../errors/friendly');
 const CommandFormatError = require('../errors/command-format');
 
-module.exports = Structures.extend('Message', Message => {
-	/**
-	 * An extension of the base Discord.js Message class to add command-related functionality.
-	 * @extends Message
-	 */
-	class CommandoMessage extends Message {
-		constructor(...args) {
-			super(...args);
+module.exports = Discord => {
 
-			/**
-			 * Whether the message contains a command (even an unknown one)
-			 * @type {boolean}
-			 */
-			this.isCommand = false;
+	const { escapeMarkdown, splitMessage } = Discord.Util
 
-			/**
-			 * Command that the message triggers, if any
-			 * @type {?Command}
-			 */
-			this.command = null;
+    /**
+     * Whether the message contains a command (even an unknown one)
+     * @type {boolean}
+     */
+    Discord.Message.prototype.isCommand = false;
 
-			/**
-			 * Argument string for the command
-			 * @type {?string}
-			 */
-			this.argString = null;
+    /**
+     * Command that the message triggers, if any
+     * @type {?Command}
+     */
+    Discord.Message.prototype.command = null;
 
-			/**
-			 * Pattern matches (if from a pattern trigger)
-			 * @type {?string[]}
-			 */
-			this.patternMatches = null;
+    /**
+     * Argument string for the command
+     * @type {?string}
+     */
+    Discord.Message.prototype.argString = null;
 
-			/**
-			 * Response messages sent, mapped by channel ID (set by the dispatcher after running the command)
-			 * @type {?Object}
-			 */
-			this.responses = null;
+    /**
+     * Pattern matches (if from a pattern trigger)
+     * @type {?string[]}
+     */
+    Discord.Message.prototype.patternMatches = null;
 
-			/**
-			 * Index of the current response that will be edited, mapped by channel ID
-			 * @type {?Object}
-			 */
-			this.responsePositions = null;
-		}
+    /**
+     * Response messages sent, mapped by channel ID (set by the dispatcher after running the command)
+     * @type {?Object}
+     */
+    Discord.Message.prototype.responses = null;
 
-		/**
-		 * Initialises the message for a command
-	 	 * @param {Command} [command] - Command the message triggers
-	 	 * @param {string} [argString] - Argument string for the command
-	 	 * @param {?Array<string>} [patternMatches] - Command pattern matches (if from a pattern trigger)
-		 * @return {Message} This message
-		 * @private
-		 */
-		initCommand(command, argString, patternMatches) {
-			this.isCommand = true;
-			this.command = command;
-			this.argString = argString;
-			this.patternMatches = patternMatches;
-			return this;
-		}
+    /**
+     * Index of the current response that will be edited, mapped by channel ID
+     * @type {?Object}
+     */
+    Discord.Message.prototype.responsePositions = null;
 
-		/**
-		 * Creates a usage string for the message's command
-		 * @param {string} [argString] - A string of arguments for the command
-		 * @param {string} [prefix=this.guild.commandPrefix || this.client.commandPrefix] - Prefix to use for the
-		 * prefixed command format
-		 * @param {User} [user=this.client.user] - User to use for the mention command format
-		 * @return {string}
-		 */
-		usage(argString, prefix, user = this.client.user) {
-			if(typeof prefix === 'undefined') {
-				if(this.guild) prefix = this.guild.commandPrefix;
-				else prefix = this.client.commandPrefix;
-			}
-			return this.command.usage(argString, prefix, user);
-		}
 
-		/**
-		 * Creates a usage string for any command
-		 * @param {string} [command] - A command + arg string
-		 * @param {string} [prefix=this.guild.commandPrefix || this.client.commandPrefix] - Prefix to use for the
-		 * prefixed command format
-		 * @param {User} [user=this.client.user] - User to use for the mention command format
-		 * @return {string}
-		 */
-		anyUsage(command, prefix, user = this.client.user) {
-			if(typeof prefix === 'undefined') {
-				if(this.guild) prefix = this.guild.commandPrefix;
-				else prefix = this.client.commandPrefix;
-			}
-			return Command.usage(command, prefix, user);
-		}
+    /**
+     * Initialises the message for a command
+       * @param {Command} [command] - Command the message triggers
+       * @param {string} [argString] - Argument string for the command
+       * @param {?Array<string>} [patternMatches] - Command pattern matches (if from a pattern trigger)
+     * @return {Message} This message
+     * @private
+     */
+    Discord.Message.prototype.initCommand = function (command, argString, patternMatches) {
+        this.isCommand = true;
+        this.command = command;
+        this.argString = argString;
+        this.patternMatches = patternMatches;
+        return this;
+    }
 
-		/**
-		 * Parses the argString into usable arguments, based on the argsType and argsCount of the command
-		 * @return {string|string[]}
-		 * @see {@link Command#run}
-		 */
-		parseArgs() {
-			switch(this.command.argsType) {
-				case 'single':
-					return this.argString.trim().replace(
-						this.command.argsSingleQuotes ? /^("|')([^]*)\1$/g : /^(")([^]*)"$/g, '$2'
-					);
-				case 'multiple':
-					return this.constructor.parseArgs(this.argString, this.command.argsCount, this.command.argsSingleQuotes);
-				default:
-					throw new RangeError(`Unknown argsType "${this.argsType}".`);
-			}
-		}
+    /**
+     * Creates a usage string for the message's command
+     * @param {string} [argString] - A string of arguments for the command
+     * @param {string} [prefix=this.guild.commandPrefix || this.client.commandPrefix] - Prefix to use for the
+     * prefixed command format
+     * @param {User} [user=this.client.user] - User to use for the mention command format
+     * @return {string}
+     */
+    Discord.Message.prototype.usage = function (argString, prefix, user = this.client.user) {
+        if (typeof prefix === 'undefined') {
+            if (this.guild) prefix = this.guild.commandPrefix;
+            else prefix = this.client.commandPrefix;
+        }
+        return this.command.usage(argString, prefix, user);
+    }
 
-		/**
-		 * Runs the command
-		 * @return {Promise<?Message|?Array<Message>>}
-		 */
-		async run() { // eslint-disable-line complexity
-			// Obtain the member if we don't have it
-			if(this.channel.type === 'text' && !this.guild.members.cache.has(this.author.id) && !this.webhookID) {
-				this.member = await this.guild.members.fetch(this.author);
-			}
+    /**
+     * Creates a usage string for any command
+     * @param {string} [command] - A command + arg string
+     * @param {string} [prefix=this.guild.commandPrefix || this.client.commandPrefix] - Prefix to use for the
+     * prefixed command format
+     * @param {User} [user=this.client.user] - User to use for the mention command format
+     * @return {string}
+     */
+    Discord.Message.prototype.anyUsage = function (command, prefix, user = this.client.user) {
+        if (typeof prefix === 'undefined') {
+            if (this.guild) prefix = this.guild.commandPrefix;
+            else prefix = this.client.commandPrefix;
+        }
+        return Command.usage(command, prefix, user);
+    }
 
-			// Obtain the member for the ClientUser if it doesn't already exist
-			if(this.channel.type === 'text' && !this.guild.members.cache.has(this.client.user.id)) {
-				await this.guild.members.fetch(this.client.user.id);
-			}
+    /**
+     * Parses the argString into usable arguments, based on the argsType and argsCount of the command
+     * @return {string|string[]}
+     * @see {@link Command#run}
+     */
+    Discord.Message.prototype.parseArgs = function () {
+        switch (this.command.argsType) {
+            case 'single':
+                return this.argString.trim().replace(
+                    this.command.argsSingleQuotes ? /^("|')([^]*)\1$/g : /^(")([^]*)"$/g, '$2'
+                );
+            case 'multiple':
+                return parseArgs(this.argString, this.command.argsCount, this.command.argsSingleQuotes);
+            default:
+                throw new RangeError(`Unknown argsType "${this.argsType}".`);
+        }
+    }
 
-			// Make sure the command is usable in this context
-			if(this.command.guildOnly && !this.guild) {
-				/**
-				 * Emitted when a command is prevented from running
-				 * @event CommandoClient#commandBlock
-				 * @param {CommandoMessage} message - Command message that the command is running from
-				 * @param {string} reason - Reason that the command was blocked
-				 * (built-in reasons are `guildOnly`, `nsfw`, `permission`, `throttling`, and `clientPermissions`)
-				 * @param {Object} [data] - Additional data associated with the block. Built-in reason data properties:
-				 * - guildOnly: none
-				 * - nsfw: none
-				 * - permission: `response` ({@link string}) to send
-				 * - throttling: `throttle` ({@link Object}), `remaining` ({@link number}) time in seconds
-				 * - clientPermissions: `missing` ({@link Array}<{@link string}>) permission names
-				 */
-				this.client.emit('commandBlock', this, 'guildOnly');
-				return this.command.onBlock(this, 'guildOnly');
-			}
+    /**
+     * Runs the command
+     * @return {Promise<?Message|?Array<Message>>}
+     */
+    Discord.Message.prototype.run = async function () { // eslint-disable-line complexity
+        // Obtain the member if we don't have it
+        if (this.channel.type === 0 && !this.guild.members.has(this.author.id) && !this.webhookID) {
+            this.member = await this.guild.members.fetch(this.author);
+        }
 
-			// Ensure the channel is a NSFW one if required
-			if(this.command.nsfw && !this.channel.nsfw) {
-				this.client.emit('commandBlock', this, 'nsfw');
-				return this.command.onBlock(this, 'nsfw');
-			}
+        // Obtain the member for the ClientUser if it doesn't already exist
+        if (this.channel.type === 0 && !this.guild.members.has(this.client.user.id)) {
+            await this.guild.members.fetch(this.client.user.id);
+        }
 
-			// Ensure the user has permission to use the command
-			const hasPermission = this.command.hasPermission(this);
-			if(!hasPermission || typeof hasPermission === 'string') {
-				const data = { response: typeof hasPermission === 'string' ? hasPermission : undefined };
-				this.client.emit('commandBlock', this, 'permission', data);
-				return this.command.onBlock(this, 'permission', data);
-			}
+        // Make sure the command is usable in this context
+        if (this.command.guildOnly && !this.guild) {
+            /**
+             * Emitted when a command is prevented from running
+             * @event AquaClient#commandBlock
+             * @param {Message} message - Command message that the command is running from
+             * @param {string} reason - Reason that the command was blocked
+             * (built-in reasons are `guildOnly`, `nsfw`, `permission`, `throttling`, and `clientPermissions`)
+             * @param {Object} [data] - Additional data associated with the block. Built-in reason data properties:
+             * - guildOnly: none
+             * - nsfw: none
+             * - permission: `response` ({@link string}) to send
+             * - throttling: `throttle` ({@link Object}), `remaining` ({@link number}) time in seconds
+             * - clientPermissions: `missing` ({@link Array}<{@link string}>) permission names
+             */
+            this.client.emit('commandBlock', this, 'guildOnly');
+            return this.command.onBlock(this, 'guildOnly');
+        }
 
-			// Ensure the client user has the required permissions
-			if(this.channel.type === 'text' && this.command.clientPermissions) {
-				const missing = this.channel.permissionsFor(this.client.user).missing(this.command.clientPermissions);
-				if(missing.length > 0) {
-					const data = { missing };
-					this.client.emit('commandBlock', this, 'clientPermissions', data);
-					return this.command.onBlock(this, 'clientPermissions', data);
-				}
-			}
+        // Ensure the channel is a NSFW one if required
+        if (this.command.nsfw && !this.channel.nsfw && !this.client.isMaster(this.author)) {
+            this.client.emit('commandBlock', this, 'nsfw');
+            return this.command.onBlock(this, 'nsfw');
+        }
 
-			// Throttle the command
-			const throttle = this.command.throttle(this.author.id);
-			if(throttle && throttle.usages + 1 > this.command.throttling.usages) {
-				const remaining = (throttle.start + (this.command.throttling.duration * 1000) - Date.now()) / 1000;
-				const data = { throttle, remaining };
-				this.client.emit('commandBlock', this, 'throttling', data);
-				return this.command.onBlock(this, 'throttling', data);
-			}
+        // Ensure the user has permission to use the command
+        const hasPermission = this.command.hasPermission(this);
+        if (!hasPermission || typeof hasPermission === 'string') {
+            const data = { response: typeof hasPermission === 'string' ? hasPermission : undefined };
+            this.client.emit('commandBlock', this, 'permission', data);
+            return this.command.onBlock(this, 'permission', data);
+        }
 
-			// Figure out the command arguments
-			let args = this.patternMatches;
-			let collResult = null;
-			if(!args && this.command.argsCollector) {
-				const collArgs = this.command.argsCollector.args;
-				const count = collArgs[collArgs.length - 1].infinite ? Infinity : collArgs.length;
-				const provided = this.constructor.parseArgs(this.argString.trim(), count, this.command.argsSingleQuotes);
+        // Ensure the client user has the required permissions
+        if (this.channel.type === 0 && this.command.clientPermissions) {
+            const available = this.channel.permissionsOf(this.client.user.id).json
+			const missing = this.command.clientPermissions.filter(x => !available[x])
+            if (missing.length > 0) {
+                const data = { missing };
+                this.client.emit('commandBlock', this, 'clientPermissions', data);
+                return this.command.onBlock(this, 'clientPermissions', data);
+            }
+        }
 
-				collResult = await this.command.argsCollector.obtain(this, provided);
-				if(collResult.cancelled) {
-					if(collResult.prompts.length === 0 || collResult.cancelled === 'promptLimit') {
-						this.client.emit('commandCancel', this.command, collResult.cancelled, this, collResult);
-						const err = new CommandFormatError(this);
-						return this.reply(err.message);
-					}
-					/**
-					 * Emitted when a command is cancelled (either by typing 'cancel' or not responding in time)
-					 * @event CommandoClient#commandCancel
-					 * @param {Command} command - Command that was cancelled
-					 * @param {string} reason - Reason for the command being cancelled
-					 * @param {CommandoMessage} message - Command message that the command ran from (see {@link Command#run})
-					 * @param {?ArgumentCollectorResult} result - Result from obtaining the arguments from the collector
-					 * (if applicable - see {@link Command#run})
-					 */
-					this.client.emit('commandCancel', this.command, collResult.cancelled, this, collResult);
-					return this.reply('Cancelled command.');
-				}
-				args = collResult.values;
-			}
-			if(!args) args = this.parseArgs();
-			const fromPattern = Boolean(this.patternMatches);
 
-			// Run the command
-			if(throttle) throttle.usages++;
-			const typingCount = this.channel.typingCount;
-			try {
-				this.client.emit('debug', `Running command ${this.command.groupID}:${this.command.memberName}.`);
-				const promise = this.command.run(this, args, fromPattern, collResult);
-				/**
-				 * Emitted when running a command
-				 * @event CommandoClient#commandRun
-				 * @param {Command} command - Command that is being run
-				 * @param {Promise} promise - Promise for the command result
-				 * @param {CommandoMessage} message - Command message that the command is running from (see {@link Command#run})
-				 * @param {Object|string|string[]} args - Arguments for the command (see {@link Command#run})
-				 * @param {boolean} fromPattern - Whether the args are pattern matches (see {@link Command#run})
-				 * @param {?ArgumentCollectorResult} result - Result from obtaining the arguments from the collector
-				 * (if applicable - see {@link Command#run})
-				 */
-				this.client.emit('commandRun', this.command, promise, this, args, fromPattern, collResult);
-				const retVal = await promise;
-				if(!(retVal instanceof Message || retVal instanceof Array || retVal === null || retVal === undefined)) {
-					throw new TypeError(oneLine`
+
+        // Throttle the command
+        const throttle = this.command.throttle(this.author.id);
+        if (throttle && throttle.usages + 1 > this.command.throttling.usages) {
+            const remaining = (throttle.start + (this.command.throttling.duration * 1000) - Date.now()) / 1000;
+            const data = { throttle, remaining };
+            this.client.emit('commandBlock', this, 'throttling', data);
+            return this.command.onBlock(this, 'throttling', data);
+        }
+
+        // Figure out the command arguments
+        let args = this.patternMatches;
+        let collResult = null;
+        if (!args && this.command.argsCollector) {
+            const collArgs = this.command.argsCollector.args;
+            const count = collArgs[collArgs.length - 1].infinite ? Infinity : collArgs.length;
+            const provided = parseArgs(this.argString.trim(), count, this.command.argsSingleQuotes);
+
+            collResult = await this.command.argsCollector.obtain(this, provided);
+            if (collResult.cancelled) {
+                if (collResult.prompts.length === 0 || collResult.cancelled === 'promptLimit') {
+                    this.client.emit('commandCancel', this.command, collResult.cancelled, this, collResult);
+                    const err = new CommandFormatError(this);
+                    return this.reply(err.message);
+                }
+                /**
+                 * Emitted when a command is cancelled (either by typing 'cancel' or not responding in time)
+                 * @event AquaClient#commandCancel
+                 * @param {Command} command - Command that was cancelled
+                 * @param {string} reason - Reason for the command being cancelled
+                 * @param {Message} message - Command message that the command ran from (see {@link Command#run})
+                 * @param {?ArgumentCollectorResult} result - Result from obtaining the arguments from the collector
+                 * (if applicable - see {@link Command#run})
+                 */
+                this.client.emit('commandCancel', this.command, collResult.cancelled, this, collResult);
+                return this.reply('Cancelled command.');
+            }
+            args = collResult.values;
+        }
+        if (!args) args = this.parseArgs();
+        const fromPattern = Boolean(this.patternMatches);
+
+        // Run the command
+        if (throttle) throttle.usages++;
+        const typingCount = this.channel.typingCount;
+        try {
+            this.client.emit('debug', `Running command ${this.command.groupID}:${this.command.memberName}.`);
+            const promise = this.command.run(this, args, fromPattern, collResult);
+            /**
+             * Emitted when running a command
+             * @event AquaClient#commandRun
+             * @param {Command} command - Command that is being run
+             * @param {Promise} promise - Promise for the command result
+             * @param {Message} message - Command message that the command is running from (see {@link Command#run})
+             * @param {Object|string|string[]} args - Arguments for the command (see {@link Command#run})
+             * @param {boolean} fromPattern - Whether the args are pattern matches (see {@link Command#run})
+             * @param {?ArgumentCollectorResult} result - Result from obtaining the arguments from the collector
+             * (if applicable - see {@link Command#run})
+             */
+            this.client.emit('commandRun', this.command, promise, this, args, fromPattern, collResult);
+            const retVal = await promise;
+            if (!(retVal instanceof Discord.Message || retVal instanceof Array || retVal === null || retVal === undefined)) {
+                throw new TypeError(oneLine`
 						Command ${this.command.name}'s run() resolved with an unknown type
 						(${retVal !== null ? retVal && retVal.constructor ? retVal.constructor.name : typeof retVal : null}).
 						Command run methods must return a Promise that resolve with a Message, Array of Messages, or null/undefined.
 					`);
-				}
-				return retVal;
-			} catch(err) {
-				/**
-				 * Emitted when a command produces an error while running
-				 * @event CommandoClient#commandError
-				 * @param {Command} command - Command that produced an error
-				 * @param {Error} err - Error that was thrown
-				 * @param {CommandoMessage} message - Command message that the command is running from (see {@link Command#run})
-				 * @param {Object|string|string[]} args - Arguments for the command (see {@link Command#run})
-				 * @param {boolean} fromPattern - Whether the args are pattern matches (see {@link Command#run})
-				 * @param {?ArgumentCollectorResult} result - Result from obtaining the arguments from the collector
-				 * (if applicable - see {@link Command#run})
-				 */
-				this.client.emit('commandError', this.command, err, this, args, fromPattern, collResult);
-				if(this.channel.typingCount > typingCount) this.channel.stopTyping();
-				if(err instanceof FriendlyError) {
-					return this.reply(err.message);
-				} else {
-					return this.command.onError(err, this, args, fromPattern, collResult);
-				}
-			}
-		}
+            }
+            return retVal;
+        } catch (err) {
+            /**
+             * Emitted when a command produces an error while running
+             * @event AquaClient#commandError
+             * @param {Command} command - Command that produced an error
+             * @param {Error} err - Error that was thrown
+             * @param {Message} message - Command message that the command is running from (see {@link Command#run})
+             * @param {Object|string|string[]} args - Arguments for the command (see {@link Command#run})
+             * @param {boolean} fromPattern - Whether the args are pattern matches (see {@link Command#run})
+             * @param {?ArgumentCollectorResult} result - Result from obtaining the arguments from the collector
+             * (if applicable - see {@link Command#run})
+             */
+            this.client.emit('commandError', this.command, err, this, args, fromPattern, collResult);
+            if (this.channel.typingCount > typingCount) this.channel.stopTyping();
+            if (err instanceof FriendlyError) {
+                return this.reply(err.message);
+            } else {
+                return this.command.onError(err, this, args, fromPattern, collResult);
+            }
+        }
+    }
 
-		/**
-		 * Responds to the command message
-		 * @param {Object} [options] - Options for the response
-		 * @return {Message|Message[]}
-		 * @private
-		 */
-		respond({ type = 'reply', content, options, lang, fromEdit = false }) {
-			const shouldEdit = this.responses && !fromEdit;
-			if(shouldEdit) {
-				if(options && options.split && typeof options.split !== 'object') options.split = {};
-			}
+    /**
+     * Responds to the command message
+     * @param {Object} [options] - Options for the response
+     * @return {Message|Message[]}
+     * @private
+     */
+    Discord.Message.prototype.respond = function ({ type = 'reply', content, options, lang, fromEdit = false }) {
+        const shouldEdit = this.responses && !fromEdit;
+        if (shouldEdit) {
+            if (options && options.split && typeof options.split !== 'object') options.split = {};
+        }
 
-			if(type === 'reply' && this.channel.type === 'dm') type = 'plain';
-			if(type !== 'direct') {
-				if(this.guild && !this.channel.permissionsFor(this.client.user).has('SEND_MESSAGES')) {
-					type = 'direct';
-				}
-			}
+        if (type === 'reply' && this.channel.type === 1) type = 'plain';
+        if (type !== 'direct') {
+            if (this.guild && !this.channel.permissionsOf(this.client.user.id).has('sendMessages')) {
+                type = 'direct';
+            }
+        }
 
-			content = resolveString(content);
 
-			switch(type) {
-				case 'plain':
-					if(!shouldEdit) return this.channel.send(content, options);
-					return this.editCurrentResponse(channelIDOrDM(this.channel), { type, content, options });
-				case 'reply':
-					if(!shouldEdit) return super.reply(content, options);
-					if(options && options.split && !options.split.prepend) options.split.prepend = `${this.author}, `;
-					return this.editCurrentResponse(channelIDOrDM(this.channel), { type, content, options });
-				case 'direct':
-					if(!shouldEdit) return this.author.send(content, options);
-					return this.editCurrentResponse('dm', { type, content, options });
-				case 'code':
-					if(!shouldEdit) return this.channel.send(content, options);
-					if(options && options.split) {
-						if(!options.split.prepend) options.split.prepend = `\`\`\`${lang || ''}\n`;
-						if(!options.split.append) options.split.append = '\n```';
-					}
-					content = `\`\`\`${lang || ''}\n${escapeMarkdown(content, true)}\n\`\`\``;
-					return this.editCurrentResponse(channelIDOrDM(this.channel), { type, content, options });
-				default:
-					throw new RangeError(`Unknown response type "${type}".`);
-			}
-		}
+        switch (type) {
+            case 'plain':
+                if (!shouldEdit) return this.channel.send(content, options);
+                return this.editCurrentResponse(channelIDOrDM(this.channel), { type, content, options });
+            case 'reply':
+                if (!shouldEdit) return this.reply(content, options);
+                if (options && options.split && !options.split.prepend) options.split.prepend = `${this.author}, `;
+                return this.editCurrentResponse(channelIDOrDM(this.channel), { type, content, options });
+            case 'direct':
+                if (!shouldEdit) return this.author.send(content, options);
+                return this.editCurrentResponse('dm', { type, content, options });
+            case 'code':
+                if (!shouldEdit) return this.channel.send(content, options);
+                if (options && options.split) {
+                    if (!options.split.prepend) options.split.prepend = `\`\`\`${lang || ''}\n`;
+                    if (!options.split.append) options.split.append = '\n```';
+                }
+                content = `\`\`\`${lang || ''}\n${escapeMarkdown(content, true)}\n\`\`\``;
+                return this.editCurrentResponse(channelIDOrDM(this.channel), { type, content, options });
+            default:
+                throw new RangeError(`Unknown response type "${type}".`);
+        }
+    }
 
-		/**
-		 * Edits a response to the command message
-		 * @param {Message|Message[]} response - The response message(s) to edit
-		 * @param {Object} [options] - Options for the response
-		 * @return {Promise<Message|Message[]>}
-		 * @private
-		 */
-		editResponse(response, { type, content, options }) {
-			if(!response) return this.respond({ type, content, options, fromEdit: true });
-			if(options && options.split) content = splitMessage(content, options.split);
+    /**
+     * Edits a response to the command message
+     * @param {Message|Message[]} response - The response message(s) to edit
+     * @param {Object} [options] - Options for the response
+     * @return {Promise<Message|Message[]>}
+     * @private
+     */
+    Discord.Message.prototype.editResponse = function (response, { type, content, options }) {
+        if (!response) return this.respond({ type, content, options, fromEdit: true });
+        if (options && options.split) content = splitMessage(content, options.split);
 
-			let prepend = '';
-			if(type === 'reply') prepend = `${this.author}, `;
+        let prepend = '';
+        if (type === 'reply') prepend = `${this.author}, `;
 
-			if(content instanceof Array) {
-				const promises = [];
-				if(response instanceof Array) {
-					for(let i = 0; i < content.length; i++) {
-						if(response.length > i) promises.push(response[i].edit(`${prepend}${content[i]}`, options));
-						else promises.push(response[0].channel.send(`${prepend}${content[i]}`));
-					}
-				} else {
-					promises.push(response.edit(`${prepend}${content[0]}`, options));
-					for(let i = 1; i < content.length; i++) {
-						promises.push(response.channel.send(`${prepend}${content[i]}`));
-					}
-				}
-				return Promise.all(promises);
-			} else {
-				if(response instanceof Array) { // eslint-disable-line no-lonely-if
-					for(let i = response.length - 1; i > 0; i--) response[i].delete();
-					return response[0].edit(`${prepend}${content}`, options);
-				} else {
-					return response.edit(`${prepend}${content}`, options);
-				}
-			}
-		}
+        if (content instanceof Array) {
+            const promises = [];
+            if (response instanceof Array) {
+                for (let i = 0; i < content.length; i++) {
+                    if (response.length > i) promises.push(response[i].edit(`${prepend}${content[i]}`, options));
+                    else promises.push(response[0].channel.send(`${prepend}${content[i]}`));
+                }
+            } else {
+                promises.push(response.edit(`${prepend}${content[0]}`, options));
+                for (let i = 1; i < content.length; i++) {
+                    promises.push(response.channel.send(`${prepend}${content[i]}`));
+                }
+            }
+            return Promise.all(promises);
+        } else {
+            if (response instanceof Array) { // eslint-disable-line no-lonely-if
+                for (let i = response.length - 1; i > 0; i--) response[i].delete();
+                return response[0].edit(`${prepend}${content}`, options);
+            } else {
+                return response.edit(`${prepend}${content}`, options);
+            }
+        }
+    }
 
-		/**
-		 * Edits the current response
-		 * @param {string} id - The ID of the channel the response is in ("DM" for direct messages)
-		 * @param {Object} [options] - Options for the response
-		 * @return {Promise<Message|Message[]>}
-		 * @private
-		 */
-		editCurrentResponse(id, options) {
-			if(typeof this.responses[id] === 'undefined') this.responses[id] = [];
-			if(typeof this.responsePositions[id] === 'undefined') this.responsePositions[id] = -1;
-			this.responsePositions[id]++;
-			return this.editResponse(this.responses[id][this.responsePositions[id]], options);
-		}
+    /**
+     * Edits the current response
+     * @param {string} id - The ID of the channel the response is in ("DM" for direct messages)
+     * @param {Object} [options] - Options for the response
+     * @return {Promise<Message|Message[]>}
+     * @private
+     */
+    Discord.Message.prototype.editCurrentResponse = function (id, options) {
+        if (typeof this.responses[id] === 'undefined') this.responses[id] = [];
+        if (typeof this.responsePositions[id] === 'undefined') this.responsePositions[id] = -1;
+        this.responsePositions[id]++;
+        return this.editResponse(this.responses[id][this.responsePositions[id]], options);
+    }
 
-		/**
-		 * Responds with a plain message
-		 * @param {StringResolvable} content - Content for the message
-		 * @param {MessageOptions} [options] - Options for the message
-		 * @return {Promise<Message|Message[]>}
-		 */
-		say(content, options) {
-			if(!options && typeof content === 'object' && !(content instanceof Array)) {
-				options = content;
-				content = '';
-			}
-			return this.respond({ type: 'plain', content, options });
-		}
+    /**
+     * Responds with a plain message
+     * @param {StringResolvable} content - Content for the message
+     * @param {MessageOptions} [options] - Options for the message
+     * @return {Promise<Message|Message[]>}
+     */
+    Discord.Message.prototype.say = function (content, options) {
+        if (!options && typeof content === 'object' && !(content instanceof Array)) {
+            options = content;
+            content = '';
+        }
+        return this.respond({ type: 'plain', content, options });
+    }
 
-		/**
-		 * Responds with a reply message
-		 * @param {StringResolvable} content - Content for the message
-		 * @param {MessageOptions} [options] - Options for the message
-		 * @return {Promise<Message|Message[]>}
-		 */
-		reply(content, options) {
-			if(!options && typeof content === 'object' && !(content instanceof Array)) {
-				options = content;
-				content = '';
-			}
-			return this.respond({ type: 'reply', content, options });
-		}
+    /**
+     * Responds with a reply message
+     * @param {StringResolvable} content - Content for the message
+     * @param {MessageOptions} [options] - Options for the message
+     * @return {Promise<Message|Message[]>}
+     */
+    Discord.Message.prototype.commandReply = function (content, options) {
+        if (!options && typeof content === 'object' && !(content instanceof Array)) {
+            options = content;
+            content = '';
+        }
+        return this.respond({ type: 'reply', content, options });
+    }
 
-		/**
-		 * Responds with a direct message
-		 * @param {StringResolvable} content - Content for the message
-		 * @param {MessageOptions} [options] - Options for the message
-		 * @return {Promise<Message|Message[]>}
-		 */
-		direct(content, options) {
-			if(!options && typeof content === 'object' && !(content instanceof Array)) {
-				options = content;
-				content = '';
-			}
-			return this.respond({ type: 'direct', content, options });
-		}
+    /**
+     * Responds with a direct message
+     * @param {StringResolvable} content - Content for the message
+     * @param {MessageOptions} [options] - Options for the message
+     * @return {Promise<Message|Message[]>}
+     */
+    Discord.Message.prototype.direct = function (content, options) {
+        if (!options && typeof content === 'object' && !(content instanceof Array)) {
+            options = content;
+            content = '';
+        }
+        return this.respond({ type: 'direct', content, options });
+    }
 
-		/**
-		 * Responds with a code message
-		 * @param {string} lang - Language for the code block
-		 * @param {StringResolvable} content - Content for the message
-		 * @param {MessageOptions} [options] - Options for the message
-		 * @return {Promise<Message|Message[]>}
-		 */
-		code(lang, content, options) {
-			if(!options && typeof content === 'object' && !(content instanceof Array)) {
-				options = content;
-				content = '';
-			}
-			if(typeof options !== 'object') options = {};
-			options.code = lang;
-			return this.respond({ type: 'code', content, options });
-		}
+    /**
+     * Responds with a code message
+     * @param {string} lang - Language for the code block
+     * @param {StringResolvable} content - Content for the message
+     * @param {MessageOptions} [options] - Options for the message
+     * @return {Promise<Message|Message[]>}
+     */
+    Discord.Message.prototype.code = function (lang, content, options) {
+        if (!options && typeof content === 'object' && !(content instanceof Array)) {
+            options = content;
+            content = '';
+        }
+        if (typeof options !== 'object') options = {};
+        options.code = lang;
+        return this.respond({ type: 'code', content, options });
+    }
 
-		/**
-		 * Responds with an embed
-		 * @param {RichEmbed|Object} embed - Embed to send
-		 * @param {StringResolvable} [content] - Content for the message
-		 * @param {MessageOptions} [options] - Options for the message
-		 * @return {Promise<Message|Message[]>}
-		 */
-		embed(embed, content = '', options) {
-			if(typeof options !== 'object') options = {};
-			options.embed = embed;
-			return this.respond({ type: 'plain', content, options });
-		}
+    /**
+     * Responds with an embed
+     * @param {RichEmbed|Object} embed - Embed to send
+     * @param {StringResolvable} [content] - Content for the message
+     * @param {MessageOptions} [options] - Options for the message
+     * @return {Promise<Message|Message[]>}
+     */
+    Discord.Message.prototype.embed = function (embed, content = '', options) {
+        if (typeof options !== 'object') options = {};
+        options.embed = embed;
+        return this.respond({ type: 'plain', content, options });
+    }
 
-		/**
-		 * Responds with a mention + embed
-		 * @param {RichEmbed|Object} embed - Embed to send
-		 * @param {StringResolvable} [content] - Content for the message
-		 * @param {MessageOptions} [options] - Options for the message
-		 * @return {Promise<Message|Message[]>}
-		 */
-		replyEmbed(embed, content = '', options) {
-			if(typeof options !== 'object') options = {};
-			options.embed = embed;
-			return this.respond({ type: 'reply', content, options });
-		}
+    /**
+     * Responds with a mention + embed
+     * @param {RichEmbed|Object} embed - Embed to send
+     * @param {StringResolvable} [content] - Content for the message
+     * @param {MessageOptions} [options] - Options for the message
+     * @return {Promise<Message|Message[]>}
+     */
+    Discord.Message.prototype.replyEmbed = function (embed, content = '', options) {
+        if (typeof options !== 'object') options = {};
+        options.embed = embed;
+        return this.respond({ type: 'reply', content, options });
+    }
 
-		/**
-		 * Finalizes the command message by setting the responses and deleting any remaining prior ones
-		 * @param {?Array<Message|Message[]>} responses - Responses to the message
-		 * @private
-		 */
-		finalize(responses) {
-			if(this.responses) this.deleteRemainingResponses();
-			this.responses = {};
-			this.responsePositions = {};
+    /**
+     * Finalizes the command message by setting the responses and deleting any remaining prior ones
+     * @param {?Array<Message|Message[]>} responses - Responses to the message
+     * @private
+     */
+    Discord.Message.prototype.finalize = function (responses) {
+        if (this.responses) this.deleteRemainingResponses();
+        this.responses = {};
+        this.responsePositions = {};
 
-			if(responses instanceof Array) {
-				for(const response of responses) {
-					const channel = (response instanceof Array ? response[0] : response).channel;
-					const id = channelIDOrDM(channel);
-					if(!this.responses[id]) {
-						this.responses[id] = [];
-						this.responsePositions[id] = -1;
-					}
-					this.responses[id].push(response);
-				}
-			} else if(responses) {
-				const id = channelIDOrDM(responses.channel);
-				this.responses[id] = [responses];
-				this.responsePositions[id] = -1;
-			}
-		}
+        if (responses instanceof Array) {
+            for (const response of responses) {
+                const channel = (response instanceof Array ? response[0] : response).channel;
+                const id = channelIDOrDM(channel);
+                if (!this.responses[id]) {
+                    this.responses[id] = [];
+                    this.responsePositions[id] = -1;
+                }
+                this.responses[id].push(response);
+            }
+        } else if (responses) {
+            const id = channelIDOrDM(responses.channel);
+            this.responses[id] = [responses];
+            this.responsePositions[id] = -1;
+        }
+    }
 
-		/**
-		 * Deletes any prior responses that haven't been updated
-		 * @private
-		 */
-		deleteRemainingResponses() {
-			for(const id of Object.keys(this.responses)) {
-				const responses = this.responses[id];
-				for(let i = this.responsePositions[id] + 1; i < responses.length; i++) {
-					const response = responses[i];
-					if(response instanceof Array) {
-						for(const resp of response) resp.delete();
-					} else {
-						response.delete();
-					}
-				}
-			}
-		}
+    /**
+     * Deletes any prior responses that haven't been updated
+     * @private
+     */
+    Discord.Message.prototype.deleteRemainingResponses = function () {
+        for (const id of Object.keys(this.responses)) {
+            const responses = this.responses[id];
+            for (let i = this.responsePositions[id] + 1; i < responses.length; i++) {
+                const response = responses[i];
+                if (response instanceof Array) {
+                    for (const resp of response) resp.delete();
+                } else {
+                    response.delete();
+                }
+            }
+        }
+    }
 
-		/**
-		 * Parses an argument string into an array of arguments
-		 * @param {string} argString - The argument string to parse
-		 * @param {number} [argCount] - The number of arguments to extract from the string
-		 * @param {boolean} [allowSingleQuote=true] - Whether or not single quotes should be allowed to wrap arguments,
-		 * in addition to double quotes
-		 * @return {string[]} The array of arguments
-		 */
-		static parseArgs(argString, argCount, allowSingleQuote = true) {
-			const argStringModified = removeSmartQuotes(argString, allowSingleQuote);
-			const re = allowSingleQuote ? /\s*(?:("|')([^]*?)\1|(\S+))\s*/g : /\s*(?:(")([^]*?)"|(\S+))\s*/g;
-			const result = [];
-			let match = [];
-			// Large enough to get all items
-			argCount = argCount || argStringModified.length;
-			// Get match and push the capture group that is not null to the result
-			while(--argCount && (match = re.exec(argStringModified))) result.push(match[2] || match[3]);
-			// If text remains, push it to the array as-is (except for wrapping quotes, which are removed)
-			if(match && re.lastIndex < argStringModified.length) {
-				const re2 = allowSingleQuote ? /^("|')([^]*)\1$/g : /^(")([^]*)"$/g;
-				result.push(argStringModified.substr(re.lastIndex).replace(re2, '$2'));
-			}
-			return result;
-		}
-	}
 
-	return CommandoMessage;
-});
+}
+
+
 
 function removeSmartQuotes(argString, allowSingleQuote = true) {
-	let replacementArgString = argString;
-	const singleSmartQuote = /[‘’]/g;
-	const doubleSmartQuote = /[“”]/g;
-	if(allowSingleQuote) replacementArgString = argString.replace(singleSmartQuote, '\'');
-	return replacementArgString
-	.replace(doubleSmartQuote, '"');
+    let replacementArgString = argString;
+    const singleSmartQuote = /[‘’]/g;
+    const doubleSmartQuote = /[“”]/g;
+    if (allowSingleQuote) replacementArgString = argString.replace(singleSmartQuote, '\'');
+    return replacementArgString
+        .replace(doubleSmartQuote, '"');
 }
 
 function channelIDOrDM(channel) {
-	if(channel.type !== 'dm') return channel.id;
-	return 'dm';
+    if (channel.type !== 1) return channel.id;
+    return 'dm';
+}
+/**
+ * Parses an argument string into an array of arguments
+ * @param {string} argString - The argument string to parse
+ * @param {number} [argCount] - The number of arguments to extract from the string
+ * @param {boolean} [allowSingleQuote=true] - Whether or not single quotes should be allowed to wrap arguments,
+ * in addition to double quotes
+ * @return {string[]} The array of arguments
+ */
+function parseArgs(argString, argCount, allowSingleQuote = true) {
+    const argStringModified = removeSmartQuotes(argString, allowSingleQuote);
+    const re = allowSingleQuote ? /\s*(?:("|')([^]*?)\1|(\S+))\s*/g : /\s*(?:(")([^]*?)"|(\S+))\s*/g;
+    const result = [];
+    let match = [];
+    // Large enough to get all items
+    argCount = argCount || argStringModified.length;
+    // Get match and push the capture group that is not null to the result
+    while (--argCount && (match = re.exec(argStringModified))) result.push(match[2] || match[3]);
+    // If text remains, push it to the array as-is (except for wrapping quotes, which are removed)
+    if (match && re.lastIndex < argStringModified.length) {
+        const re2 = allowSingleQuote ? /^("|')([^]*)\1$/g : /^(")([^]*)"$/g;
+        result.push(argStringModified.substr(re.lastIndex).replace(re2, '$2'));
+    }
+    return result;
 }

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const discord = require('discord.js');
+const Collection = require('@discordjs/collection');
 const Command = require('./commands/base');
 const CommandGroup = require('./commands/group');
 const CommandoMessage = require('./extensions/message');
@@ -22,19 +22,19 @@ class CommandoRegistry {
 		 * Registered commands, mapped by their name
 		 * @type {Collection<string, Command>}
 		 */
-		this.commands = new discord.Collection();
+		this.commands = new Collection();
 
 		/**
 		 * Registered command groups, mapped by their ID
 		 * @type {Collection<string, CommandGroup>}
 		 */
-		this.groups = new discord.Collection();
+		this.groups = new Collection();
 
 		/**
 		 * Registered argument types, mapped by their ID
 		 * @type {Collection<string, ArgumentType>}
 		 */
-		this.types = new discord.Collection();
+		this.types = new Collection();
 
 		/**
 		 * Fully resolved path to the bot's commands directory

--- a/src/types/category-channel.js
+++ b/src/types/category-channel.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js');
+const { escapeMarkdown } = require('discord.js').Util;
 
 class CategoryChannelArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/category-channel.js
+++ b/src/types/category-channel.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js').Util;
+const { escapeMarkdown } = require('discord.js').Util
 
 class CategoryChannelArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/channel.js
+++ b/src/types/channel.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js').Util;
+const { escapeMarkdown } = require('discord.js').Util
 
 class ChannelArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/channel.js
+++ b/src/types/channel.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js');
+const { escapeMarkdown } = require('discord.js').Util;
 
 class ChannelArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/command.js
+++ b/src/types/command.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js');
+const { escapeMarkdown } = require('discord.js').Util;
 
 class CommandArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/command.js
+++ b/src/types/command.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js').Util;
+const { escapeMarkdown } = require('discord.js').Util
 
 class CommandArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/custom-emoji.js
+++ b/src/types/custom-emoji.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js');
+const { escapeMarkdown } = require('discord.js').Util;
 
 class CustomEmojiArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/custom-emoji.js
+++ b/src/types/custom-emoji.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js').Util;
+const { escapeMarkdown } = require('discord.js').Util
 
 class CustomEmojiArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/group.js
+++ b/src/types/group.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js').Util;
+const { escapeMarkdown } = require('discord.js').Util
 
 class GroupArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/group.js
+++ b/src/types/group.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js');
+const { escapeMarkdown } = require('discord.js').Util;
 
 class GroupArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/member.js
+++ b/src/types/member.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js').Util;
+const { escapeMarkdown } = require('discord.js').Util
 
 class MemberArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/member.js
+++ b/src/types/member.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js');
+const { escapeMarkdown } = require('discord.js').Util;
 
 class MemberArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/role.js
+++ b/src/types/role.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js');
+const { escapeMarkdown } = require('discord.js').Util;
 
 class RoleArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/role.js
+++ b/src/types/role.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js').Util;
+const { escapeMarkdown } = require('discord.js').Util
 
 class RoleArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/text-channel.js
+++ b/src/types/text-channel.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js').Util;
+const { escapeMarkdown } = require('discord.js').Util
 
 class TextChannelArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/text-channel.js
+++ b/src/types/text-channel.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js');
+const { escapeMarkdown } = require('discord.js').Util;
 
 class TextChannelArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/user.js
+++ b/src/types/user.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js').Util;
+const { escapeMarkdown } = require('discord.js').Util
 
 class UserArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/user.js
+++ b/src/types/user.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js');
+const { escapeMarkdown } = require('discord.js').Util;
 
 class UserArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/voice-channel.js
+++ b/src/types/voice-channel.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js');
+const { escapeMarkdown } = require('discord.js').Util;
 
 class VoiceChannelArgumentType extends ArgumentType {
 	constructor(client) {

--- a/src/types/voice-channel.js
+++ b/src/types/voice-channel.js
@@ -1,6 +1,6 @@
 const ArgumentType = require('./base');
 const { disambiguation } = require('../util');
-const { escapeMarkdown } = require('discord.js').Util;
+const { escapeMarkdown } = require('discord.js').Util
 
 class VoiceChannelArgumentType extends ArgumentType {
 	constructor(client) {

--- a/test/bot.js
+++ b/test/bot.js
@@ -3,11 +3,14 @@ const commando = require('../src');
 const path = require('path');
 const oneLine = require('common-tags').oneLine;
 const sqlite = require('sqlite');
+const sqlite3 = require('sqlite3')
 const token = require('./auth').token;
+const Discord = require('discord.js');
 
 const client = new commando.Client({
 	owner: '90997305578106880',
-	commandPrefix: 'cdev'
+	commandPrefix: 'cdev',
+	intents: ["GUILD_MESSAGES", "GUILDS", "GUILD_PRESENCES"]
 });
 
 client
@@ -51,7 +54,10 @@ client
 	});
 
 client.setProvider(
-	sqlite.open(path.join(__dirname, 'database.sqlite3')).then(db => new commando.SQLiteProvider(db))
+	sqlite.open({
+		filename: "database.sqlite3",
+		driver: sqlite3.Database
+	  }).then(db => new commando.SQLiteProvider(db))
 ).catch(console.error);
 
 client.registry

--- a/test/commands/util/split.js
+++ b/test/commands/util/split.js
@@ -1,4 +1,5 @@
 const commando = require('../../../src');
+const { splitMessage } = require('discord.js').Util
 
 module.exports = class SplitCommand extends commando.Command {
 	constructor(client) {
@@ -24,6 +25,9 @@ module.exports = class SplitCommand extends commando.Command {
 	async run(msg, args) {
 		let content = '';
 		for(let i = 0; i < args.length; i++) content += `${i % 500 === 0 ? '\n' : ''}a`;
-		return [await msg.reply(content, { split: true })];
+
+		let splitContent = splitMessage(content)
+		splitContent.map(x => msg.reply(x));
+		return;
 	}
 };

--- a/test/commands/util/user-info.js
+++ b/test/commands/util/user-info.js
@@ -31,13 +31,13 @@ module.exports = class UserInfoCommand extends commando.Command {
 
 			**❯ Member Details**
 			${member.nickname !== null ? ` • Nickname: ${member.nickname}` : ' • No nickname'}
-			 • Roles: ${member.roles.map(roles => `\`${roles.name}\``).join(', ')}
+			 • Roles: ${member.roles.cache.map(roles => `\`${roles.name}\``).join(', ')}
 			 • Joined at: ${member.joinedAt}
 
 			**❯ User Details**
 			 • Created at: ${user.createdAt}${user.bot ? '\n • Is a bot account' : ''}
-			 • Status: ${user.presence.status}
-			 • Game: ${user.presence.game ? user.presence.game.name : 'None'}
+			 • Status: ${member.presence.status}
+			 • Game: ${member.presence.game ? member.presence.game.name : 'None'}
 		`);
 	}
 };


### PR DESCRIPTION
Uhh so just tried to rewrite discord.js commando. 

Since structures were removed in the master branch, I tried directly modifying the prototypes so it's kinda hacky but it still works without any bugs so far (tested all commands in the test directory)

There are not many changes except for rewriting all Utility function imports from `('discord.js')` to `('discord.js').Util` and completely rewriting the structure extensions,

This has been tested with the master branch of discord.js and I am yet to encounter any bugs since the latest commit.

I'm not sure if creating a pull request to master would be a good idea but I just wanted to try.

The changes are breaking and do not work with discord.js v12.